### PR TITLE
#19 feat: 팔로우 관련 API 구현

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/follow/controller/FollowController.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/controller/FollowController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/follows")
+@RequestMapping("/api/auth/follows")
 public class FollowController {
 
     private final FollowCommandService followCommandService;

--- a/src/main/java/UMC_7th/Closit/domain/follow/controller/FollowController.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/controller/FollowController.java
@@ -1,22 +1,34 @@
 package UMC_7th.Closit.domain.follow.controller;
 
+import UMC_7th.Closit.domain.follow.converter.FollowConverter;
+import UMC_7th.Closit.domain.follow.dto.FollowRequestDTO;
+import UMC_7th.Closit.domain.follow.dto.FollowResponseDTO;
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.follow.service.FollowCommandService;
+import UMC_7th.Closit.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/follows")
 public class FollowController {
 
+    private final FollowCommandService followCommandService;
+
     @Operation(summary = "팔로우 생성", description = "새로운 팔로우를 생성합니다.")
     @PostMapping
-    public ResponseEntity<String> createFollow(@RequestBody String follow) {
-        return ResponseEntity.ok("Created Follow: " + follow);
+    public ApiResponse<FollowResponseDTO.CreateFollowResultDTO> createFollow(@RequestBody @Valid FollowRequestDTO.CreateFollowDTO request) {
+        Follow follow = followCommandService.createFollow(request);
+        return ApiResponse.onSuccess(FollowConverter.toCreateFollowResultDTO(follow));
     }
 
     @Operation(summary = "팔로우 삭제", description = "특정 팔로우를 삭제합니다.")
     @DeleteMapping("/{follow_id}")
-    public ResponseEntity<String> deleteFollow(@PathVariable Long follow_id) {
-        return ResponseEntity.ok("Deleted Follow with ID: " + follow_id);
+    public ApiResponse<String> deleteFollow(@PathVariable Long follow_id) {
+        followCommandService.deleteFollow(follow_id);
+        return ApiResponse.onSuccess("Deleted Follow with ID: " + follow_id);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/follow/converter/FollowConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/converter/FollowConverter.java
@@ -1,0 +1,37 @@
+package UMC_7th.Closit.domain.follow.converter;
+
+import UMC_7th.Closit.domain.follow.dto.FollowRequestDTO;
+import UMC_7th.Closit.domain.follow.dto.FollowResponseDTO;
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public class FollowConverter {
+
+    public static FollowResponseDTO.CreateFollowResultDTO toCreateFollowResultDTO(Follow follow) {
+        return FollowResponseDTO.CreateFollowResultDTO.builder()
+                .followId(follow.getId())
+                .followerId(follow.getFollower().getId())
+                .followingId(follow.getFollowing().getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static FollowResponseDTO.FollowDTO toFollowDTO(Follow follow) {
+        return FollowResponseDTO.FollowDTO.builder()
+                .followId(follow.getId())
+                .followerId(follow.getFollower().getId())
+                .followingId(follow.getFollowing().getId())
+                .createdAt(follow.getCreatedAt())
+                .updatedAt(follow.getUpdatedAt())
+                .build();
+    }
+
+    public static Follow toFollow(FollowRequestDTO.CreateFollowDTO request, User follwer, User following) {
+        return Follow.builder()
+                .follower(follwer)
+                .following(following)
+                .build();
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowRequestDTO.java
@@ -1,0 +1,20 @@
+package UMC_7th.Closit.domain.follow.dto;
+
+import UMC_7th.Closit.global.validation.annotation.ExistUser;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class FollowRequestDTO {
+
+    @Getter
+    public static class CreateFollowDTO {
+
+        @NotNull(message = "팔로워 id는 필수 입력 값입니다.")
+        @ExistUser
+        private Long follower;
+
+        @NotNull(message = "팔로잉 id는 필수 입력 값입니다.")
+        @ExistUser
+        private Long following;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowResponseDTO.java
@@ -1,0 +1,34 @@
+package UMC_7th.Closit.domain.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class FollowResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateFollowResultDTO {
+        private Long followId;
+        private Long followerId;
+        private Long followingId;
+        private LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FollowDTO {
+        private Long followId;
+        private Long followerId;
+        private Long followingId;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/entity/Follow.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/entity/Follow.java
@@ -17,10 +17,6 @@ public class Follow extends BaseEntity {
     @Column(name = "follow_id")
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id", nullable = false)
     private User follower;

--- a/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,8 @@
+package UMC_7th.Closit.domain.follow.repository;
+
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
@@ -1,8 +1,16 @@
 package UMC_7th.Closit.domain.follow.repository;
 
 import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
+    // 특정 유저를 팔로우하는 사람 목록 조회 (팔로워)
+    Slice<Follow> findByFollowing(User user, Pageable pageable);
+
+    // 특정 유저가 팔로우하는 사람 목록 조회 (팔로잉)
+    Slice<Follow> findByFollower(User user, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/follow/service/FollowCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/service/FollowCommandService.java
@@ -1,0 +1,11 @@
+package UMC_7th.Closit.domain.follow.service;
+
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.follow.dto.FollowRequestDTO;
+
+public interface FollowCommandService {
+
+    Follow createFollow(FollowRequestDTO.CreateFollowDTO request);
+
+    void deleteFollow(Long followId);
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/service/FollowCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/service/FollowCommandServiceImpl.java
@@ -1,0 +1,45 @@
+package UMC_7th.Closit.domain.follow.service;
+
+import UMC_7th.Closit.domain.follow.repository.FollowRepository;
+import UMC_7th.Closit.domain.follow.converter.FollowConverter;
+import UMC_7th.Closit.domain.follow.dto.FollowRequestDTO;
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.UserRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.handler.FollowHandler;
+import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FollowCommandServiceImpl implements FollowCommandService {
+
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public Follow createFollow(FollowRequestDTO.CreateFollowDTO request) {
+        User follower = userRepository.findById(request.getFollower())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        User following = userRepository.findById(request.getFollowing())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Follow newFollow = FollowConverter.toFollow(request, follower, following);
+
+        return followRepository.save(newFollow);
+    }
+
+    @Override
+    @Transactional
+    public void deleteFollow(Long followId) {
+        Follow follow = followRepository.findById(followId)
+                .orElseThrow(() -> new FollowHandler(ErrorStatus.FOLLOW_NOT_FOUND));
+
+        followRepository.delete(follow);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/service/FollowQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/service/FollowQueryService.java
@@ -1,0 +1,8 @@
+package UMC_7th.Closit.domain.follow.service;
+
+import UMC_7th.Closit.domain.follow.entity.Follow;
+
+public interface FollowQueryService {
+
+    Follow findFollow(Long id);
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/service/FollowQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/service/FollowQueryServiceImpl.java
@@ -1,0 +1,24 @@
+package UMC_7th.Closit.domain.follow.service;
+
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.follow.repository.FollowRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.handler.FollowHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowQueryServiceImpl implements FollowQueryService {
+
+    private final FollowRepository followRepository;
+
+    @Override
+    public Follow findFollow(Long id) {
+
+        return followRepository.findById(id)
+                .orElseThrow(() -> new FollowHandler(ErrorStatus.FOLLOW_NOT_FOUND));
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/highlight/controller/HighlightController.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/controller/HighlightController.java
@@ -10,7 +10,6 @@ import UMC_7th.Closit.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -49,7 +48,6 @@ public class HighlightController {
     @DeleteMapping("/{highlight_id}")
     public ApiResponse<String> deleteHighlight(@PathVariable Long highlight_id) {
         highlightCommandService.deleteHighlight(highlight_id);
-
         return ApiResponse.onSuccess("Deleted Highlight with ID: " + highlight_id);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/highlight/repository/HighlightRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/repository/HighlightRepository.java
@@ -2,6 +2,7 @@ package UMC_7th.Closit.domain.highlight.repository;
 
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,5 +14,5 @@ public interface HighlightRepository extends JpaRepository<Highlight, Long> {
     @Query("SELECT h FROM Highlight h LEFT JOIN FETCH h.highlightPosts hp WHERE h.id = :highlightId")
     Optional<Highlight> findByIdWithPosts(Long highlightId);
 
-    Slice<Highlight> findAllByUser(User user);
+    Slice<Highlight> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/highlight/repository/HighlightRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/repository/HighlightRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface HighlightRepository extends JpaRepository<Highlight, Long> {

--- a/src/main/java/UMC_7th/Closit/domain/highlight/service/HighlightQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/service/HighlightQueryService.java
@@ -2,8 +2,6 @@ package UMC_7th.Closit.domain.highlight.service;
 
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 
-import java.util.Optional;
-
 public interface HighlightQueryService {
 
     Highlight findHighlight(Long id);

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package UMC_7th.Closit.domain.user.controller;
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.user.converter.UserConverter;
 import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
+import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.service.UserCommandService;
 import UMC_7th.Closit.domain.user.service.UserQueryService;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
@@ -23,16 +24,26 @@ public class UserController {
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
 
-    @Operation(summary = "사용자의 팔로워 조회", description = "특정 사용자의 팔로워 목록을 조회합니다.")
+    @Operation(summary = "사용자의 팔로워 목록 조회", description = "특정 사용자의 팔로워 목록을 조회합니다.")
     @GetMapping("/{user_id}/followers")
-    public ResponseEntity<List<String>> getFollowers(@PathVariable Long user_id) {
-        return ResponseEntity.ok(List.of("Follower1", "Follower2"));
+    public UserResponseDTO.UserFollowerSliceDTO getUserFollowers(
+            @PathVariable Long user_id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Slice<User> followerSlice = userQueryService.getFollowerList(user_id, PageRequest.of(page, size));
+        return UserConverter.toUserFollowerSliceDTO(followerSlice);
     }
 
-    @Operation(summary = "사용자의 팔로잉 조회", description = "특정 사용자의 팔로잉 목록을 조회합니다.")
-    @GetMapping("/{user_id}/followings")
-    public ResponseEntity<List<String>> getFollowings(@PathVariable Long user_id) {
-        return ResponseEntity.ok(List.of("Following1", "Following2"));
+    @Operation(summary = "사용자의 팔로잉 목록 조회", description = "특정 사용자의 팔로잉 목록을 조회합니다.")
+    @GetMapping("/{user_id}/following")
+    public UserResponseDTO.UserFollowingSliceDTO getUserFollowing(
+            @PathVariable Long user_id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Slice<User> followingSlice = userQueryService.getFollowingList(user_id, PageRequest.of(page, size));
+        return UserConverter.toUserFollowingSliceDTO(followingSlice);
     }
 
     @Operation(summary = "사용자의 알림 목록 조회", description = "특정 사용자의 알림 목록을 조회합니다.")

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import UMC_7th.Closit.domain.user.service.UserQueryService;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -42,9 +43,13 @@ public class UserController {
 
     @Operation(summary = "사용자의 하이라이트 목록 조회", description = "특정 사용자의 하이라이트 목록을 조회합니다.")
     @GetMapping("/{user_id}/highlights")
-    public ApiResponse<UserResponseDTO.UserHighlightListDTO> getUserHighlights(@PathVariable Long user_id) {
-        Slice<Highlight> userHighlights = userQueryService.getHighlightList(user_id);
+    public UserResponseDTO.UserHighlightSliceDTO getUserHighlights(
+            @PathVariable Long user_id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
-        return ApiResponse.onSuccess(UserConverter.toUserHighlightListDTO(userHighlights));
+        Slice<Highlight> highlightSlice = userQueryService.getHighlightList(user_id, PageRequest.of(page, size));
+
+        return UserConverter.toUserHighlightSliceDTO(highlightSlice);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -5,6 +5,7 @@ import UMC_7th.Closit.domain.highlight.dto.HighlightResponseDTO;
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
 import UMC_7th.Closit.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -23,13 +24,14 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserHighlightListDTO toUserHighlightListDTO(Slice<Highlight> highlightList) {
-        List<HighlightResponseDTO.HighlightDTO> highlightDTOs = highlightList.stream()
-                .map(HighlightConverter::toHighlightDTO)
-                .collect(Collectors.toList());
+    public static UserResponseDTO.UserHighlightSliceDTO toUserHighlightSliceDTO(@NotNull Slice<Highlight> highlightSlice) {
+        Slice<HighlightResponseDTO.HighlightDTO> highlightDTOs = highlightSlice.map(HighlightConverter::toHighlightDTO);
 
-        return UserResponseDTO.UserHighlightListDTO.builder()
-                .highlightList(highlightDTOs)
+        return UserResponseDTO.UserHighlightSliceDTO.builder()
+                .highlights(highlightDTOs.getContent())  // 현재 페이지의 하이라이트 목록
+                .hasNext(highlightSlice.hasNext())       // 다음 페이지 존재 여부
+                .pageNumber(highlightSlice.getNumber())  // 현재 페이지 번호
+                .size(highlightSlice.getSize())          // 페이지 크기
                 .build();
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -28,30 +28,18 @@ public class UserConverter {
         Slice<HighlightResponseDTO.HighlightDTO> highlightDTOs = highlightSlice.map(HighlightConverter::toHighlightDTO);
 
         return UserResponseDTO.UserHighlightSliceDTO.builder()
-                .highlights(highlightDTOs.getContent())  // 현재 페이지의 하이라이트 목록
-                .hasNext(highlightSlice.hasNext())       // 다음 페이지 존재 여부
-                .pageNumber(highlightSlice.getNumber())  // 현재 페이지 번호
-                .size(highlightSlice.getSize())          // 페이지 크기
+                .highlights(highlightDTOs.getContent())
+                .hasNext(highlightSlice.hasNext())
+                .pageNumber(highlightSlice.getNumber())
+                .size(highlightSlice.getSize())
                 .build();
     }
 
-    public static UserResponseDTO.UserFollwerListDTO toUserFollwerListDTO(Slice<User> followerList) {
-        List<UserResponseDTO.UserDTO> follwerDTOs = followerList.stream()
-                .map(UserConverter::toUserDTO)
-                .collect(Collectors.toList());
-
-        return UserResponseDTO.UserFollwerListDTO.builder()
-                .followerList(follwerDTOs)
-                .build();
+    public static UserResponseDTO.UserFollowerSliceDTO toUserFollowerSliceDTO(Slice<User> followerSlice) {
+        return UserResponseDTO.UserFollowerSliceDTO.from(followerSlice);
     }
 
-    public static UserResponseDTO.UserFollwingListDTO toUserFollwingListDTO(Slice<User> followingList) {
-        List<UserResponseDTO.UserDTO> follwingDTOs = followingList.stream()
-                .map(UserConverter::toUserDTO)
-                .collect(Collectors.toList());
-
-        return UserResponseDTO.UserFollwingListDTO.builder()
-                .followingList(follwingDTOs)
-                .build();
+    public static UserResponseDTO.UserFollowingSliceDTO toUserFollowingSliceDTO(Slice<User> followingSlice) {
+        return UserResponseDTO.UserFollowingSliceDTO.from(followingSlice);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -4,12 +4,24 @@ import UMC_7th.Closit.domain.highlight.converter.HighlightConverter;
 import UMC_7th.Closit.domain.highlight.dto.HighlightResponseDTO;
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
+import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class UserConverter {
+
+    public static UserResponseDTO.UserDTO toUserDTO(User user) {
+        return UserResponseDTO.UserDTO.builder()
+                .userId(user.getId())
+                .clositId(user.getClositId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .birth(user.getBirth())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
 
     public static UserResponseDTO.UserHighlightListDTO toUserHighlightListDTO(Slice<Highlight> highlightList) {
         List<HighlightResponseDTO.HighlightDTO> highlightDTOs = highlightList.stream()
@@ -18,6 +30,26 @@ public class UserConverter {
 
         return UserResponseDTO.UserHighlightListDTO.builder()
                 .highlightList(highlightDTOs)
+                .build();
+    }
+
+    public static UserResponseDTO.UserFollwerListDTO toUserFollwerListDTO(Slice<User> followerList) {
+        List<UserResponseDTO.UserDTO> follwerDTOs = followerList.stream()
+                .map(UserConverter::toUserDTO)
+                .collect(Collectors.toList());
+
+        return UserResponseDTO.UserFollwerListDTO.builder()
+                .followerList(follwerDTOs)
+                .build();
+    }
+
+    public static UserResponseDTO.UserFollwingListDTO toUserFollwingListDTO(Slice<User> followingList) {
+        List<UserResponseDTO.UserDTO> follwingDTOs = followingList.stream()
+                .map(UserConverter::toUserDTO)
+                .collect(Collectors.toList());
+
+        return UserResponseDTO.UserFollwingListDTO.builder()
+                .followingList(follwingDTOs)
                 .build();
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
@@ -2,6 +2,8 @@ package UMC_7th.Closit.domain.user.dto;
 
 import UMC_7th.Closit.domain.follow.dto.FollowResponseDTO;
 import UMC_7th.Closit.domain.highlight.dto.HighlightResponseDTO;
+import UMC_7th.Closit.domain.user.converter.UserConverter;
+import UMC_7th.Closit.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,15 +52,39 @@ public class UserResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UserFollwerListDTO {
-        private List<UserDTO> followerList;
+    public static class UserFollowerSliceDTO {
+        private List<UserDTO> followers;
+        private boolean hasNext;
+        private int pageNumber;
+        private int size;
+
+        public static UserFollowerSliceDTO from(Slice<User> slice) {
+            return UserFollowerSliceDTO.builder()
+                    .followers(slice.map(UserConverter::toUserDTO).getContent())
+                    .hasNext(slice.hasNext())
+                    .pageNumber(slice.getNumber())
+                    .size(slice.getSize())
+                    .build();
+        }
     }
 
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UserFollwingListDTO {
-        private List<UserDTO> followingList;
+    public static class UserFollowingSliceDTO {
+        private List<UserDTO> following;
+        private boolean hasNext;
+        private int pageNumber;
+        private int size;
+
+        public static UserFollowingSliceDTO from(Slice<User> slice) {
+            return UserFollowingSliceDTO.builder()
+                    .following(slice.map(UserConverter::toUserDTO).getContent())
+                    .hasNext(slice.hasNext())
+                    .pageNumber(slice.getNumber())
+                    .size(slice.getSize())
+                    .build();
+        }
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
@@ -1,11 +1,13 @@
 package UMC_7th.Closit.domain.user.dto;
 
+import UMC_7th.Closit.domain.follow.dto.FollowResponseDTO;
 import UMC_7th.Closit.domain.highlight.dto.HighlightResponseDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class UserResponseDTO {
@@ -14,7 +16,36 @@ public class UserResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class UserDTO {
+        private Long userId;
+        private String clositId;
+        private String name;
+        private String email;
+        private LocalDate birth;
+        private String profileImage;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class UserHighlightListDTO {
         private List<HighlightResponseDTO.HighlightDTO> highlightList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserFollwerListDTO {
+        private List<UserDTO> followerList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserFollwingListDTO {
+        private List<UserDTO> followingList;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -29,8 +30,20 @@ public class UserResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UserHighlightListDTO {
-        private List<HighlightResponseDTO.HighlightDTO> highlightList;
+    public static class UserHighlightSliceDTO {
+        private List<HighlightResponseDTO.HighlightDTO> highlights;
+        private boolean hasNext;
+        private int pageNumber;
+        private int size;
+
+        public static UserHighlightSliceDTO from(Slice<HighlightResponseDTO.HighlightDTO> slice) {
+            return UserHighlightSliceDTO.builder()
+                    .highlights(slice.getContent())
+                    .hasNext(slice.hasNext())
+                    .pageNumber(slice.getNumber())
+                    .size(slice.getSize())
+                    .build();
+        }
     }
 
     @Builder

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -85,11 +85,11 @@ public class User extends BaseEntity {
     @Builder.Default
     private List<BattleLikes> battleLikesList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Follow> followerList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Follow> followingList = new ArrayList<>();
 

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -87,7 +87,11 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
-    private List<Follow> followList = new ArrayList<>();
+    private List<Follow> followerList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Follow> followingList = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
@@ -2,13 +2,12 @@ package UMC_7th.Closit.domain.user.service;
 
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-
-import java.util.List;
 
 public interface UserQueryService {
 
-    Slice<Highlight> getHighlightList(Long userId);
+    Slice<Highlight> getHighlightList(Long userId, Pageable pageable);
 
     Slice<User> getFollowerList(Long userId);
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
@@ -9,7 +9,7 @@ public interface UserQueryService {
 
     Slice<Highlight> getHighlightList(Long userId, Pageable pageable);
 
-    Slice<User> getFollowerList(Long userId);
+    Slice<User> getFollowerList(Long userId, Pageable pageable);
 
-    Slice<User> getFollowingList(Long userId);
+    Slice<User> getFollowingList(Long userId, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
@@ -1,6 +1,7 @@
 package UMC_7th.Closit.domain.user.service;
 
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
+import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.domain.Slice;
 
 import java.util.List;
@@ -8,4 +9,8 @@ import java.util.List;
 public interface UserQueryService {
 
     Slice<Highlight> getHighlightList(Long userId);
+
+    Slice<User> getFollowerList(Long userId);
+
+    Slice<User> getFollowingList(Long userId);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package UMC_7th.Closit.domain.user.service;
 
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.follow.repository.FollowRepository;
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.highlight.repository.HighlightRepository;
 import UMC_7th.Closit.domain.user.converter.UserConverter;
@@ -23,6 +25,7 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     private final UserRepository userRepository;
     private final HighlightRepository highlightRepository;
+    private final FollowRepository followRepository;
 
     @Override
     public Slice<Highlight> getHighlightList(Long userId, Pageable pageable) {
@@ -30,5 +33,23 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         return highlightRepository.findAllByUser(user, pageable);
+    }
+
+    @Override
+    public Slice<User> getFollowerList(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Slice<Follow> followers = followRepository.findByFollowing(user, pageable);
+        return followers.map(Follow::getFollower);
+    }
+
+    @Override
+    public Slice<User> getFollowingList(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        Slice<Follow> followings = followRepository.findByFollower(user, pageable);
+        return followings.map(Follow::getFollowing);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -2,11 +2,14 @@ package UMC_7th.Closit.domain.user.service;
 
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.highlight.repository.HighlightRepository;
+import UMC_7th.Closit.domain.user.converter.UserConverter;
+import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
 import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,10 +25,10 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final HighlightRepository highlightRepository;
 
     @Override
-    public Slice<Highlight> getHighlightList(Long userId) {
+    public Slice<Highlight> getHighlightList(Long userId, Pageable pageable) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        return highlightRepository.findAllByUser(user);
+        return highlightRepository.findAllByUser(user, pageable);
     }
 }

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -35,7 +35,10 @@ public enum ErrorStatus implements BaseErrorCode {
     HIGHLIGHT_NOT_FOUND(HttpStatus.NOT_FOUND, "HIGHLIGHT4041", "하이라이트가 존재하지 않습니다."),
 
     // 하이라이트 게시글 관련 에러
-    HIGHLIGHT_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "HIGHLIGHTPOST4041", "하이라이트 게시글이 존재하지 않습니다.");
+    HIGHLIGHT_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "HIGHLIGHTPOST4041", "하이라이트 게시글이 존재하지 않습니다."),
+
+    // 팔로우 관련 에러
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4041", "팔로우가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/exception/handler/FollowHandler.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/exception/handler/FollowHandler.java
@@ -1,0 +1,11 @@
+package UMC_7th.Closit.global.apiPayload.exception.handler;
+
+import UMC_7th.Closit.global.apiPayload.code.BaseErrorCode;
+import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
+
+public class FollowHandler extends GeneralException {
+
+    public FollowHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/global/config/WebConfig.java
+++ b/src/main/java/UMC_7th/Closit/global/config/WebConfig.java
@@ -1,0 +1,19 @@
+package UMC_7th.Closit.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc  // Spring MVC 설정 활성화
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")  // 모든 경로에 CORS 적용
+                .allowedOrigins("http://localhost:3000")  // 프론트엔드 주소
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/global/validation/annotation/ExistFollow.java
+++ b/src/main/java/UMC_7th/Closit/global/validation/annotation/ExistFollow.java
@@ -1,0 +1,18 @@
+package UMC_7th.Closit.global.validation.annotation;
+
+import UMC_7th.Closit.global.validation.validator.FollowExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = FollowExistValidator.class)
+@Target({ ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistFollow {
+
+    String message() default "해당하는 팔로우가 존재하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/UMC_7th/Closit/global/validation/validator/FollowExistValidator.java
+++ b/src/main/java/UMC_7th/Closit/global/validation/validator/FollowExistValidator.java
@@ -1,7 +1,7 @@
 package UMC_7th.Closit.global.validation.validator;
 
-import UMC_7th.Closit.domain.post.repository.PostRepository;
-import UMC_7th.Closit.global.validation.annotation.ExistPost;
+import UMC_7th.Closit.domain.follow.repository.FollowRepository;
+import UMC_7th.Closit.global.validation.annotation.ExistFollow;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
@@ -9,26 +9,26 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class PostExistValidator implements ConstraintValidator<ExistPost, Long> {
+public class FollowExistValidator implements ConstraintValidator<ExistFollow, Long> {
 
-    private final PostRepository postRepository;
+    private final FollowRepository followRepository;
 
     @Override
-    public void initialize(ExistPost constraintAnnotation) {
+    public void initialize(ExistFollow constraintAnnotation) {
         ConstraintValidator.super.initialize(constraintAnnotation);
     }
 
     @Override
-    public boolean isValid(Long postId, ConstraintValidatorContext context) {
-        if (postId == null) {
+    public boolean isValid(Long followId, ConstraintValidatorContext context) {
+        if (followId == null) {
             return true; // null은 검증하지 않음
         }
 
-        boolean isValid = postRepository.existsById(postId);
+        boolean isValid = followRepository.existsById(followId);
 
         if (!isValid) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("POST_NOT_FOUND")
+            context.buildConstraintViolationWithTemplate("FOLLOW_NOT_FOUND")
                     .addConstraintViolation();
         }
 

--- a/src/main/java/UMC_7th/Closit/global/validation/validator/HighlightExistValidator.java
+++ b/src/main/java/UMC_7th/Closit/global/validation/validator/HighlightExistValidator.java
@@ -19,12 +19,12 @@ public class HighlightExistValidator implements ConstraintValidator<ExistHighlig
     }
 
     @Override
-    public boolean isValid(Long userId, ConstraintValidatorContext context) {
-        if (userId == null) {
+    public boolean isValid(Long highlightId, ConstraintValidatorContext context) {
+        if (highlightId == null) {
             return true; // null은 검증하지 않음
         }
 
-        boolean isValid = highlightRepository.existsById(userId);
+        boolean isValid = highlightRepository.existsById(highlightId);
 
         if (!isValid) {
             context.disableDefaultConstraintViolation();

--- a/src/main/java/UMC_7th/Closit/global/validation/validator/HighlightPostExistValidator.java
+++ b/src/main/java/UMC_7th/Closit/global/validation/validator/HighlightPostExistValidator.java
@@ -19,12 +19,12 @@ public class HighlightPostExistValidator implements ConstraintValidator<ExistHig
     }
 
     @Override
-    public boolean isValid(Long userId, ConstraintValidatorContext context) {
-        if (userId == null) {
+    public boolean isValid(Long highlightPostId, ConstraintValidatorContext context) {
+        if (highlightPostId == null) {
             return true; // null은 검증하지 않음
         }
 
-        boolean isValid = highlightPostRepository.existsById(userId);
+        boolean isValid = highlightPostRepository.existsById(highlightPostId);
 
         if (!isValid) {
             context.disableDefaultConstraintViolation();


### PR DESCRIPTION
## #️⃣연관된 이슈

> #32 [#19 feat: 팔로우 관련 API 구현]

## 📝작업 내용

> 팔로우 생성
> 팔로우 삭제
> 사용자의 팔로워 조회
> 사용자의 팔로잉 조회

### 스크린샷 (선택)

> 팔로우 생성
![스크린샷 2025-01-31 031956](https://github.com/user-attachments/assets/4cffd74f-9d1e-481f-90b3-63c3ea976e1a)

> 팔로우 삭제
![스크린샷 2025-01-31 032541](https://github.com/user-attachments/assets/d39cb3df-9a87-472f-8ee5-f58908564985)

> 사용자의 팔로워 조회
![스크린샷 2025-01-31 032036](https://github.com/user-attachments/assets/0903a3a7-5ba1-4e84-ad64-cf824a440cff)

> 사용자의 팔로잉 조회
![스크린샷 2025-01-31 032016](https://github.com/user-attachments/assets/ba773f90-f1cd-462a-b1c7-8794e3b432d7)

## 💬리뷰 요구사항(선택)

