### PR TITLE
#22 feat: 투표 조회 API

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -12,18 +12,20 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/api/auth/communities/battle")
 public class BattleController {
 
     private final BattleCommandService battleCommandService;
     private final BattleQueryService battleQueryService;
 
     @Operation(summary = "새로운 배틀 생성")
-    @PostMapping("/communities/battle/upload")
+    @PostMapping("/upload")
     public ApiResponse<BattleResponseDTO.CreateBattleResultDTO> createBattle(@RequestBody @Valid BattleRequestDTO.CreateBattleDTO request) {
 
         Battle battle = battleCommandService.createBattle(request);
@@ -32,7 +34,7 @@ public class BattleController {
     }
 
     @Operation(summary = "배틀 신청")
-    @PostMapping("/communities/battle/challenge/upload/{battle_id}")
+    @PostMapping("/challenge/upload/{battle_id}")
     public ApiResponse<BattleResponseDTO.ChallengeBattleResultDTO> challengeBattle(@RequestBody @Valid BattleRequestDTO.ChallengeBattleDTO request,
                                                                                    @PathVariable("battle_id") Long battleId) {
 
@@ -42,7 +44,7 @@ public class BattleController {
     }
 
     @Operation(summary = "배틀 투표")
-    @PostMapping("/communities/battle/{battle_id}/voting")
+    @PostMapping("/{battle_id}/voting")
     public ApiResponse<BattleResponseDTO.VoteBattleResultDTO> voteBattle(@RequestBody @Valid BattleRequestDTO.VoteBattleDTO request,
                                                                          @PathVariable("battle_id") Long battleId) {
 
@@ -52,16 +54,17 @@ public class BattleController {
     }
 
     @Operation(summary = "배틀 게시글 목록 조회")
-    @GetMapping("/communities/battle")
-    public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getBattleList(@RequestParam(name = "page") Integer page) {
+    @GetMapping()
+    public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getBattleList(@RequestParam(name = "user_id") Long userId, //@AuthenticationPrincipal Authentication auth
+                                                                             @RequestParam(name = "page") Integer page) {
 
-        Slice<Battle> battleList = battleQueryService.getBattleList(page);
+        Slice<Battle> battleList = battleQueryService.getBattleList(userId, page);
 
         return ApiResponse.onSuccess(BattleConverter.battlePreviewListDTO(battleList));
     }
 
     @Operation(summary = "배틀 챌린지 게시글 목록 조회")
-    @GetMapping("/communities/battle/challenge")
+    @GetMapping("/challenge")
     public ApiResponse<BattleResponseDTO.ChallengeBattlePreviewListDTO> getChallengeBattleList(@RequestParam(name = "page") Integer page) {
 
         Slice<Battle> challengeBattleList = battleQueryService.getChallengeBattleList(page);
@@ -70,7 +73,7 @@ public class BattleController {
     }
 
     @Operation(summary = "배틀 삭제")
-    @DeleteMapping("/communities/battle/{battle_id}")
+    @DeleteMapping("/{battle_id}")
     public ApiResponse<Void> deleteBattle(@PathVariable("battle_id") Long battleId) {
 
         battleCommandService.deleteBattle(battleId);

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -48,7 +48,6 @@ public class BattleResponseDTO {
         private LocalDateTime createdAt;
     }
 
-
     @Builder
     @Getter
     @NoArgsConstructor

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -41,7 +41,8 @@ public class Battle extends BaseEntity {
     private Integer secondVotingCnt = 0;
 
     @Column
-    private Integer likeCount;
+    @Builder.Default
+    private Integer likeCount = 0;
 
     @OneToMany(mappedBy = "battle", cascade = CascadeType.ALL)
     @Builder.Default
@@ -88,6 +89,14 @@ public class Battle extends BaseEntity {
 
     public void incrementSecondVotingCnt() { // 두 번째 게시글 투표
         this.secondVotingCnt++;
+    }
+
+    public void setFirstVotingCnt (Integer firstVotingCnt) { // 배틀 게시글 목록 조회
+        this.firstVotingCnt = firstVotingCnt;
+    }
+
+    public void setSecondVotingCnt (Integer secondVotingCnt) {
+        this.secondVotingCnt = secondVotingCnt;
     }
 
     public void increaseLikeCount() { // 배틀 좋아요 생성

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/VoteRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/VoteRepository.java
@@ -4,5 +4,5 @@ import UMC_7th.Closit.domain.battle.entity.Vote;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
-    boolean existsByBattleIdAndUserId(Long battleId, Long userId); // 배틀 투표
+    boolean existsByBattleIdAndUserId(Long battleId, Long userId); // 배틀 투표, 배틀 게시글 목록 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
@@ -7,9 +7,6 @@ import java.util.Optional;
 
 public interface BattleQueryService {
 
-    Optional<Battle> findBattle(Long battleId); // 배틀 게시글 목록 조회
-    Slice<Battle> getBattleList (Integer page);
-
-    Optional<Battle> findChallengeBattle(Long battleId); // 배틀 챌린지 게시글 목록 조회
-    Slice<Battle> getChallengeBattleList (Integer page);
+    Slice<Battle> getBattleList (Long userId, Integer page); // 배틀 게시글 목록 조회
+    Slice<Battle> getChallengeBattleList (Integer page); // 배틀 챌린지 게시글 목록 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -2,6 +2,7 @@ package UMC_7th.Closit.domain.battle.service.BattleService;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
 import UMC_7th.Closit.domain.battle.repository.BattleRepository;
+import UMC_7th.Closit.domain.battle.repository.VoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -9,39 +10,35 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BattleQueryServiceImpl implements BattleQueryService {
 
     private final BattleRepository battleRepository;
+    private final VoteRepository voteRepository;
 
     @Override
-    public Optional<Battle> findBattle(Long battleId) { // 배틀 게시글 목록 조회
-
-        return battleRepository.findById(battleId);
-    }
-
-    @Override
-    public Slice<Battle> getBattleList(Integer page) {
+    public Slice<Battle> getBattleList(Long userId, Integer page) { // 배틀 게시글 목록 조회
         Pageable pageable = PageRequest.of(page, 10);
 
         // secondPostId가 not null 인 것을 기준으로 조회
         Slice<Battle> battleList = battleRepository.findByPost2IsNotNull(pageable);
 
+        // 투표하지 않았으면 해당 배틀 투표 수 null로 표시
+        battleList.forEach(battle -> {
+            boolean isVoted = voteRepository.existsByBattleIdAndUserId(battle.getId(), userId);
+            if (!isVoted) {
+                battle.setFirstVotingCnt(null);
+                battle.setSecondVotingCnt(null);
+            }
+        });
+
         return battleList;
     }
 
     @Override
-    public Optional<Battle> findChallengeBattle(Long battleId) { // 배틀 챌린지 게시글 목록 조회
-
-        return battleRepository.findById(battleId);
-    }
-
-    @Override
-    public Slice<Battle> getChallengeBattleList(Integer page) {
+    public Slice<Battle> getChallengeBattleList(Integer page) { // 배틀 챌린지 게시글 목록 조회
         Pageable pageable = PageRequest.of(page, 10);
 
         // secondPostId가 null 인 것을 기준으로 조회

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Post.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Post.java
@@ -31,12 +31,6 @@ public class Post extends BaseEntity {
     private String backImage;
 
     @Column(nullable = false)
-    private boolean isBattle;
-
-    @Column
-    private Integer votingCount;
-
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Visibility visibility;
 
@@ -77,16 +71,4 @@ public class Post extends BaseEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ItemTag> itemTagList = new ArrayList<>();
-
-    public void isBattle(boolean isBattle) { // 배틀 생성
-        this.isBattle = isBattle;
-    }
-
-    public void incrementVotingCount() { // 배틀 투표
-        if (this.votingCount == null) {
-            this.votingCount = 1;
-        } else {
-            this.votingCount += votingCount;
-        }
-    }
 }

--- a/src/main/java/UMC_7th/Closit/global/config/AmazonConfig.java
+++ b/src/main/java/UMC_7th/Closit/global/config/AmazonConfig.java
@@ -30,8 +30,8 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${cloud.aws.s3.path.test}")
-    private String testPath;
+//    @Value("${cloud.aws.s3.path.test}")
+//    private String testPath;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/UMC_7th/Closit/global/s3/AmazonS3Manager.java
+++ b/src/main/java/UMC_7th/Closit/global/s3/AmazonS3Manager.java
@@ -35,7 +35,7 @@ public class AmazonS3Manager {
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
 
-    public String generateTestKeyName(Uuid uuid) {
-        return amazonConfig.getTestPath() + '/' + uuid.getUuid();
-    }
+//    public String generateTestKeyName(Uuid uuid) {
+//        return amazonConfig.getTestPath() + '/' + uuid.getUuid();
+//    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #42 #22 feat: 투표 조회 API 구현 

## 📝작업 내용

> 배틀 게시글 목록 조회 시, 투표한 배틀의 투표 수만 보이게 수정
투표 X인 배틀은 null로 표시 

### 스크린샷 (선택)
> 투표한 배틀의 투표 수만 조회 
![스크린샷 2025-02-04 164058](https://github.com/user-attachments/assets/db0b18b5-3f27-4377-a6a4-dd10be96ed5c)
![스크린샷 2025-02-04 164133](https://github.com/user-attachments/assets/dc0cd8d5-2b8b-4b12-9cf5-57519bf3f103)
(userId = 1은 투표 완료 -> 투표 수 조회 가능)
![스크린샷 2025-02-04 163927](https://github.com/user-attachments/assets/1915ba54-cf91-4668-8dca-4163cbb53a4f)
(userId = 2 투표 X -> 투표 수 null로 표시)

## 💬리뷰 요구사항(선택)

> AmazonConfig 내 오류 발생한 부분 주석 처리 했습니다.
