### PR TITLE
#29 feat: 유저 프로필 이미지 업로드 구현

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -43,9 +43,7 @@ public class UserController {
     @PostMapping(
             value = "/{user_id}/profile-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}
     )
-    public ApiResponse<UserResponseDTO.UserInfoDTO> registerProfileImage(@RequestPart(value = "user_image", required = true) MultipartFile profileImage) {
-        log.info("profileImage: {}", profileImage.getOriginalFilename());
-
+    public ApiResponse<UserResponseDTO.UserInfoDTO> registerProfileImage(@RequestPart(value = "user_image", required = false) MultipartFile profileImage) {
         User userInfo = userCommandService.registerProfileImage(profileImage);
         return ApiResponse.onSuccess(UserConverter.toUserInfoDTO(userInfo));
     }

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -13,8 +13,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -35,6 +37,17 @@ public class UserController {
 
         userCommandService.deleteUser(user_id);
         return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(summary = "사용자 프로필 이미지 등록", description = "특정 사용자의 프로필 이미지를 등록합니다.")
+    @PostMapping(
+            value = "/{user_id}/profile-image", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}
+    )
+    public ApiResponse<UserResponseDTO.UserInfoDTO> registerProfileImage(@RequestPart(value = "user_image", required = true) MultipartFile profileImage) {
+        log.info("profileImage: {}", profileImage.getOriginalFilename());
+
+        User userInfo = userCommandService.registerProfileImage(profileImage);
+        return ApiResponse.onSuccess(UserConverter.toUserInfoDTO(userInfo));
     }
 
     @Operation(summary = "사용자 정보 조회", description = "특정 사용자의 정보를 조회합니다.")

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -105,4 +105,9 @@ public class User extends BaseEntity {
         this.role = newRole;
         return this;
     }
+
+    public User updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+        return this;
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
@@ -2,10 +2,14 @@ package UMC_7th.Closit.domain.user.service;
 
 import UMC_7th.Closit.domain.user.dto.RegisterResponseDTO;
 import UMC_7th.Closit.domain.user.dto.UserRequestDTO;
+import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserCommandService {
 
     RegisterResponseDTO registerUser (UserRequestDTO.CreateUserDTO userRequestDto);
     void deleteUser(Long userId);
+
+    User registerProfileImage (MultipartFile file);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -99,6 +99,7 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // 사용자가 프로필 이미지를 삭제하려는 경우
         if (file == null || file.isEmpty()) {
+            amazonS3Manager.deleteFile(currentUser.getProfileImage());
             currentUser.updateProfileImage(null);
             return currentUser;
         }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -7,12 +7,18 @@ import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
+import UMC_7th.Closit.global.s3.AmazonS3Manager;
+import UMC_7th.Closit.global.s3.UuidRepository;
+import UMC_7th.Closit.global.s3.entity.Uuid;
 import UMC_7th.Closit.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
 
 
 @Service
@@ -23,7 +29,11 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
     private final SecurityUtil securityUtil;
+
+    private final AmazonS3Manager amazonS3Manager;
+    private final UuidRepository uuidRepository;
 
     @Override
     public RegisterResponseDTO registerUser (UserRequestDTO.CreateUserDTO userRequestDto) {
@@ -35,7 +45,6 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         // Password Encoding
         String encodedPassword = passwordEncoder.encode(userRequestDto.getPassword());
-
 
         // UserDto to User
         User user = User.builder()
@@ -63,8 +72,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         User currentUser= securityUtil.getCurrentUser(); // 로그인한 사용자 (username 또는 userId 기반)
 
 //        log.info("현재 로그인된 사용자: username = {}", currentUser.getName());
-        User targetUser = userRepository.findById(user_id)
-                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        User targetUser = getOrElseThrow(user_id);
 
         // 자기 자신이거나 관리자 권한이 있는 경우만 삭제 가능
         if (!currentUser.getId().equals(user_id) ||
@@ -74,6 +82,35 @@ public class UserCommandServiceImpl implements UserCommandService {
 
 //        log.info("사용자 삭제 진행: userId={}, 삭제자={}", user_id, currentUser.getName());
         userRepository.delete(targetUser);
+    }
+
+    @Override
+    public User registerProfileImage (MultipartFile file) {
+        if (!securityUtil.isAuthenticated()) {
+            throw new UserHandler(ErrorStatus.USER_NOT_AUTHORIZED);
+        }
+
+        User currentUser = securityUtil.getCurrentUser();
+        log.info("Register profile image service: currentUser={}", currentUser.getId());
+        log.info("Register profile image service: file={}", file.getOriginalFilename());
+
+
+        if (currentUser.getProfileImage() != null) {
+            amazonS3Manager.deleteFile(currentUser.getProfileImage());
+        }
+
+        String uuid = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+        String storedLocation = amazonS3Manager.uploadFile(amazonS3Manager.generateProfileImageKeyName(savedUuid), file);
+
+        currentUser.updateProfileImage(storedLocation);
+        return currentUser;
+    }
+
+    private User getOrElseThrow (Long userId) {
+        log.info("Get user by userId: userId={}", userId);
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     }
 
 

--- a/src/main/java/UMC_7th/Closit/global/config/AmazonConfig.java
+++ b/src/main/java/UMC_7th/Closit/global/config/AmazonConfig.java
@@ -33,6 +33,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.path.test}")
     private String testPath;
 
+    @Value("${cloud.aws.s3.path.profileImage}")
+    private String profileImagePath;
+
     @PostConstruct
     public void init() {
         this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
@@ -40,7 +43,6 @@ public class AmazonConfig {
 
     @Bean
     public AmazonS3 amazonS3() {
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         return AmazonS3ClientBuilder.standard()
                 .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))

--- a/src/main/java/UMC_7th/Closit/global/s3/AmazonS3Manager.java
+++ b/src/main/java/UMC_7th/Closit/global/s3/AmazonS3Manager.java
@@ -30,6 +30,7 @@ public class AmazonS3Manager {
         log.info("File extension: {}", file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".")));
         log.info("Original file name: {}", file.getOriginalFilename());
 
+        metadata.setContentType(file.getContentType());
         metadata.setContentLength(file.getSize());
         try {
             amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));

--- a/src/main/java/UMC_7th/Closit/global/s3/AmazonS3Manager.java
+++ b/src/main/java/UMC_7th/Closit/global/s3/AmazonS3Manager.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -25,6 +26,10 @@ public class AmazonS3Manager {
 
     public String uploadFile(String keyName, MultipartFile file){
         ObjectMetadata metadata = new ObjectMetadata();
+        log.info("File size: {}", file.getSize());
+        log.info("File extension: {}", file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf(".")));
+        log.info("Original file name: {}", file.getOriginalFilename());
+
         metadata.setContentLength(file.getSize());
         try {
             amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
@@ -35,7 +40,41 @@ public class AmazonS3Manager {
         return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
     }
 
+    public void deleteFile (String profileImage) {
+        if (profileImage == null || profileImage.isEmpty()) {
+            log.info("profileImage is null or empty");
+            return;
+        }
+
+        try {
+            String fileKey = extractS3Key(profileImage);
+            amazonS3.deleteObject(amazonConfig.getBucket(), fileKey);
+            log.info("file deleted successfully");
+        } catch (Exception e) {
+            log.error("error at AmazonS3Manager deleteFile : {}", (Object) e.getStackTrace());
+        }
+
+
+        amazonS3.deleteObject(amazonConfig.getBucket(), profileImage);
+    }
+
+    private String extractS3Key(String fileUrl) {
+        String bucketUrl = "https://" + amazonConfig.getBucket() + ".s3." + amazonConfig.getRegion() + ".amazonaws.com/";
+
+        if (fileUrl.startsWith(bucketUrl)) {
+            return fileUrl.substring(bucketUrl.length());
+        }
+
+        throw new IllegalArgumentException("잘못된 S3 파일 URL: " + fileUrl);
+    }
+
     public String generateTestKeyName(Uuid uuid) {
         return amazonConfig.getTestPath() + '/' + uuid.getUuid();
     }
+
+    public String generateProfileImageKeyName(Uuid uuid) {
+        return amazonConfig.getProfileImagePath() + '/' + uuid.getUuid();
+    }
+
+
 }

--- a/src/main/java/UMC_7th/Closit/security/SecurityUtil.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityUtil.java
@@ -28,4 +28,9 @@ public class SecurityUtil {
                 () -> new UserHandler(ErrorStatus.USER_NOT_FOUND)
         );
     }
+
+    public boolean isAuthenticated(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#29 feat: 유저 프로필 사진 업로드 구현

## 📝작업 내용

유저 프로필 이미지를 업로드 하는 기능을 구현했습니다.
로그인이 필요하며, 로그인한 해당 유저가 바꾸는 것이므로 userId는 따로 전달 안하고 SecurityContextHolder에서 현재 사용자의 정보를 얻을 수 있도록 하였습니다.
사용자가 이미지를 업로드하면 해당 이미지의 s3 url을 반환하고
아무 이미지도 업로드 하지 않으면 s3의 이미지를 삭제함과 동시에 profile image column 값을 null로 변환합니다.
profileImage column 값 변경은 User entity에 updateProfileImage 메서드를 통해 이루어지게끔 하였습니다.

### 스크린샷 (선택)
1. 아무 이미지도 업로드하지 않았을 때
![image](https://github.com/user-attachments/assets/0ea3f22b-0ded-41ab-a50c-94e559f07544)
2. 이미지를 업로드했을 때
- response
![image](https://github.com/user-attachments/assets/7a7df7d9-afa8-421e-b6ed-ea1685876300)
- s3화면
![image](https://github.com/user-attachments/assets/7cae47ca-a784-464b-9626-2b1ad658f2da)
response의 profileImageUrl 필드 값에 나타난 이미지 이름과 s3에 저장된 이미지 이름이 동일한 것을 확인할 수 있습니다.


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
