### PR TITLE
#37 feat: API 필터 적용

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
@@ -70,7 +70,6 @@ public class UserAuthServiceImpl implements UserAuthService {
 
         // Refresh Token에서 email 추출
         String email = currentUser.getEmail();
-        log.info("email: {}", email);
 
         // 서버에 저장된 refresh token과 비교
         RefreshToken savedToken = refreshTokenRepository.findByUsername(email)
@@ -80,7 +79,6 @@ public class UserAuthServiceImpl implements UserAuthService {
             log.info("savedToken not equals refreshToken");
             throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN);
         }
-        log.info("username: {}", email);
 
         Role role = currentUser.getRole();
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -87,15 +87,8 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     public User registerProfileImage (MultipartFile file) {
 
-        // 로그인 여부 확인
-        if (!securityUtil.isAuthenticated()) {
-            throw new UserHandler(ErrorStatus.USER_NOT_AUTHORIZED);
-        }
-
         // 현재 로그인된 사용자 정보
         User currentUser = securityUtil.getCurrentUser();
-//        log.info("Register profile image service: currentUser={}", currentUser.getId());
-//        log.info("Register profile image service: file={}", file.getOriginalFilename());
 
         // 사용자가 프로필 이미지를 삭제하려는 경우
         if (file == null || file.isEmpty()) {

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -64,7 +64,6 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     @Override
     public User getUserInfo(String clositId) {
-
         return userRepository.findByClositId(clositId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     }

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -19,10 +19,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 사용자 관련 에러
     PASSWORD_NOT_CORRESPOND (HttpStatus.UNAUTHORIZED, "LOGIN4001", "비밀번호가 일치하지 않습니다."), // 인증 실패
-    USER_ALREADY_EXIST (HttpStatus.CONFLICT, "REGISTER4001", "이미 존재하는 사용자입니다."), // 리소스 충돌 (회원가입 시)
-    USER_NOT_AUTHORIZED (HttpStatus.FORBIDDEN, "USER4001", "사용자 권한이 없습니다."), // 권한 부족
-    USER_NOT_MATCH (HttpStatus.FORBIDDEN, "USER4002", "사용자가 일치하지 않습니다."), // 권한 부족
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003","이미 존재하는 이메일입니다"), // 리소스 충돌
+    USER_NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "USER4001", "로그인이 필요합니다. 다시 로그인해주세요."),
+    USER_ALREADY_EXIST (HttpStatus.CONFLICT, "REGISTER4002", "이미 존재하는 사용자입니다."), // 리소스 충돌 (회원가입 시)
+    USER_NOT_AUTHORIZED (HttpStatus.FORBIDDEN, "USER4003", "사용자 권한이 없습니다."), // 권한 부족
+    USER_NOT_MATCH (HttpStatus.FORBIDDEN, "USER4004", "사용자가 일치하지 않습니다."), // 권한 부족
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4005","이미 존재하는 이메일입니다"), // 리소스 충돌
     USER_NOT_FOUND (HttpStatus.NOT_FOUND, "USER4041", "사용자가 존재하지 않습니다."), // 존재하지 않는 사용자
 
     // ClositId 관련 에러

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -18,15 +18,15 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "찾을 수 없습니다."),
 
     // 사용자 관련 에러
-    PASSWORD_NOT_CORRESPOND (HttpStatus.BAD_REQUEST, "LOGIN4001", "비밀번호가 일치하지 않습니다."),
-    USER_ALREADY_EXIST (HttpStatus.BAD_REQUEST, "REGISTER4001", "이미 존재하는 사용자입니다."),
-    USER_NOT_AUTHORIZED (HttpStatus.BAD_REQUEST, "USER4001", "사용자 권한이 없습니다."),
-    USER_NOT_MATCH (HttpStatus.BAD_REQUEST, "USER4002", "사용자가 일치하지 않습니다."),
-    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER4003","이미 존재하는 이메일입니다"),
-    USER_NOT_FOUND (HttpStatus.NOT_FOUND, "USER4041", "사용자가 존재하지 않습니다."),
+    PASSWORD_NOT_CORRESPOND (HttpStatus.UNAUTHORIZED, "LOGIN4001", "비밀번호가 일치하지 않습니다."), // 인증 실패
+    USER_ALREADY_EXIST (HttpStatus.CONFLICT, "REGISTER4001", "이미 존재하는 사용자입니다."), // 리소스 충돌 (회원가입 시)
+    USER_NOT_AUTHORIZED (HttpStatus.FORBIDDEN, "USER4001", "사용자 권한이 없습니다."), // 권한 부족
+    USER_NOT_MATCH (HttpStatus.FORBIDDEN, "USER4002", "사용자가 일치하지 않습니다."), // 권한 부족
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4003","이미 존재하는 이메일입니다"), // 리소스 충돌
+    USER_NOT_FOUND (HttpStatus.NOT_FOUND, "USER4041", "사용자가 존재하지 않습니다."), // 존재하지 않는 사용자
 
     // ClositId 관련 에러
-    CLOSITID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER4004", "이미 존재하는 ClositId입니다."),
+    CLOSITID_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4004", "이미 존재하는 ClositId입니다."), // 리소스 충돌
 
     // 토큰 관련 에러
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -29,12 +30,12 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
-//                .exceptionHandling((exceptionHandling) -> exceptionHandling
-//                        .accessDeniedHandler(jwtAccessDeniedHandler)
-//                        .authenticationEntryPoint(jwtAuthenticationEntryPoint))
-//                // disable session management
-//                .sessionManagement((sessionManagement) -> sessionManagement
-//                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling((exceptionHandling) -> exceptionHandling
+                        .accessDeniedHandler(jwtAccessDeniedHandler) // 인증은 되었지만 권한이 부족할 때
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 인증에 실패했을 때
+                // disable session management
+                .sessionManagement((sessionManagement) -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // 폼 기반 로그인 설정
                 .formLogin(formLogin -> formLogin
                         .loginPage("/login")
@@ -45,10 +46,11 @@ public class SecurityConfig {
                         .invalidateHttpSession(true))
                 // 경로 접속 권한 설정
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
-                        .requestMatchers("/api/auth/**", "/api/public/**").permitAll()
+                        // Swagger, login, register, refresh 허용
                         .requestMatchers("/","/swagger-ui/**","/v3/api-docs/**").permitAll()
-                        .requestMatchers("/user").hasRole("USER")
-                        .requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers("/api/auth/register",
+                                         "/api/auth/login",
+                                         "/api/auth/refresh").permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                                          "/api/auth/login",
                                          "/api/auth/refresh").permitAll()
                         .anyRequest().authenticated())
+                // UsernamePasswordAuthenticationFilter 전에 JwtAuthenticationFilter 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAccessDeniedHandler.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.security.jwt;
 
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,10 +19,11 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Override
-    public void handle (HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        ErrorStatus userNotAuthorized = ErrorStatus.USER_NOT_AUTHORIZED;
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setStatus(userNotAuthorized.getReasonHttpStatus().getHttpStatus().value());
 
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("code", "COMMON403");

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAccessDeniedHandler.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.security.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -8,12 +9,27 @@ import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @Override
     public void handle (HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.sendError(HttpServletResponse.SC_FORBIDDEN, "권한이 없습니다.");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("code", "COMMON403");
+        errorResponse.put("message", "권한이 없습니다.");
+        // 클라이언트에서 이전 화면으로 이동하도록 안내할 수 있는 추가 필드
+        errorResponse.put("action", "goBack");
+
+        String jsonResponse = OBJECT_MAPPER.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.security.jwt;
 
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,8 +15,21 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence (HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+
+        ErrorStatus errorStatus = ErrorStatus.USER_NOT_AUTHORIZED;
+//        response.setContentType("application/json");
+//        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+//        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"" + authException.getMessage() + "\"}");
+
         response.setContentType("application/json");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"" + authException.getMessage() + "\"}");
+        response.setStatus(errorStatus.getReasonHttpStatus().getHttpStatus().value());
+
+        // JSON 응답에 에러 코드, 메시지, 타임스탬프 등을 포함하여 구조화된 형태로 반환
+        String jsonResponse = "{" +
+                "\"code\": \"" + errorStatus.getCode() + "\"," +
+                "\"message\": \"" + errorStatus.getMessage() + "\"," +
+                "\"timestamp\": \"" + System.currentTimeMillis() + "\"" +
+                "}";
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package UMC_7th.Closit.security.jwt;
 
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,27 +10,38 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @Override
     public void commence (HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
 
-        ErrorStatus errorStatus = ErrorStatus.USER_NOT_AUTHORIZED;
 //        response.setContentType("application/json");
 //        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 //        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"" + authException.getMessage() + "\"}");
 
+        ErrorStatus errorStatus = ErrorStatus.USER_NOT_AUTHORIZED;
+
         response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
         response.setStatus(errorStatus.getReasonHttpStatus().getHttpStatus().value());
 
-        // JSON 응답에 에러 코드, 메시지, 타임스탬프 등을 포함하여 구조화된 형태로 반환
-        String jsonResponse = "{" +
-                "\"code\": \"" + errorStatus.getCode() + "\"," +
-                "\"message\": \"" + errorStatus.getMessage() + "\"," +
-                "\"timestamp\": \"" + System.currentTimeMillis() + "\"" +
-                "}";
+        String formattedTimestamp = LocalDateTime.now().format(FORMATTER);
+
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("code", errorStatus.getCode());
+        errorResponse.put("message", errorStatus.getMessage());
+        errorResponse.put("timestamp", formattedTimestamp);
+
+        String jsonResponse = OBJECT_MAPPER.writeValueAsString(errorResponse);
         response.getWriter().write(jsonResponse);
     }
 }

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 //        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 //        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"" + authException.getMessage() + "\"}");
 
-        ErrorStatus errorStatus = ErrorStatus.USER_NOT_AUTHORIZED;
+        ErrorStatus errorStatus = ErrorStatus.USER_NOT_LOGGED_IN;
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationEntryPoint.java
@@ -24,10 +24,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence (HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
 
-//        response.setContentType("application/json");
-//        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-//        response.getWriter().write("{\"error\": \"Unauthorized\", \"message\": \"" + authException.getMessage() + "\"}");
-
         ErrorStatus errorStatus = ErrorStatus.USER_NOT_LOGGED_IN;
 
         response.setContentType("application/json");

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
@@ -44,7 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             Role role = Role.valueOf(roleString); // String->Role 반환
             UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
 
-            // 🔹 SecurityContext에 UserDetails 설정
+            // SecurityContext에 UserDetails 설정
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     userDetails, // principal을 UserDetails 객체로 설정
                     null,


### PR DESCRIPTION
## #️⃣연관된 이슈

#78 

## 📝작업 내용
login, register, refresh api를 제외한 API에 로그인 인증 후 접근할 수 있도록 필터를 추가했습니다.

동작 흐름
1. 클라이언트가 요청을 보내면, 요청은 먼저 JwtAuthenticationFilter를 거치게 됩니다.
2. JWT 토큰이 포함되어 있으면 유효성 검사를 수행하고, 유효한 경우 SecurityContext에 인증 정보를 설정합니다.
3. 요청이 인증이 필요한 API에 접근하려 할 때 Spring Security는 SecurityContext(사용자 인증정보 담아두는 곳)를 확인하여 인증 여부를 판단합니다.
4. 만약 인증 정보가 없거나 유효하지 않으면, 설정된 JwtAuthenticationEntryPoint가 호출되어 401 Unauthorized 응답을 반환합니다.
5. 인증은 되었으나 필요한 권한이 부족하면 JwtAccessDeniedHandler가 호출되어 403 Forbidden 응답을 반환합니다.

### 스크린샷 (선택)
1. 로그인 이전 사용자 정보 조회 API 접근했을 때
![image](https://github.com/user-attachments/assets/23202392-c02f-484d-8a7a-30704ea95a56)

2. 로그인 이후 사용자 저오 조회 API 접근했을 때
![image](https://github.com/user-attachments/assets/66fdec9a-76f9-4b95-a46b-243371c6d076)
