### PR TITLE
#38 feat: 사용자 history 조회 API

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
@@ -28,7 +28,7 @@ public class HistoryController {
             description = """
                     ## 사용자 날짜 별 히스토리 썸네일 조회
                     ### Parameters
-                    page [조회할 페이지 번호] - 0부터 시작, 31개씩 보여줌
+                    page [조회할 페이지 번호] - 0부터 시작, 50개씩 보여줌
                     """)
     public ApiResponse<HistoryResponseDTO.DataHistoryThumbnailListDTO> dateThumbnailList (@RequestParam(name = "page") Integer page) { // 히스토리 썸네일 조회
 
@@ -49,5 +49,19 @@ public class HistoryController {
         List<Post> datePreviewList = historyQueryService.getHistoryPreviewList(localDate);
 
         return ApiResponse.onSuccess(HistoryConverter.dateHistoryPreviewListDTO(localDate, datePreviewList));
+    }
+
+    @GetMapping("/pointcolor")
+    @Operation(summary = "사용자의 히스토리 포인트 컬러 썸네일 조회",
+            description = """
+                    ## 사용자 날짜 별 히스토리 포인트 컬러 썸네일 조회
+                    ### Parameters
+                    page [조회할 페이지 번호] - 0부터 시작, 50개씩 보여줌
+                    """)
+    public ApiResponse<HistoryResponseDTO.ColorHistoryThumbnailListDTO> colorThumbnailList (@RequestParam(name = "page") Integer page) { // 히스토리 포인트 색상 썸네일 조회
+
+        Slice<Post> colorThumbnailList = historyQueryService.getHistoryColorThumbnailList(page);
+
+        return ApiResponse.onSuccess(HistoryConverter.colorHistoryThumbnailListDTO(colorThumbnailList));
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
@@ -24,9 +24,9 @@ public class HistoryController {
     private final HistoryQueryService historyQueryService;
 
     @GetMapping
-    @Operation(summary = "사용자의 히스토리 조회 - 날짜",
+    @Operation(summary = "사용자의 히스토리 썸네일 조회",
             description = """
-                    ## 사용자 날짜 별 히스토리 조회
+                    ## 사용자 날짜 별 히스토리 썸네일 조회
                     ### Parameters
                     page [조회할 페이지 번호] - 0부터 시작, 31개씩 보여줌
                     """)
@@ -38,7 +38,7 @@ public class HistoryController {
     }
 
     @GetMapping("/detail")
-    @Operation(summary = "사용자의 히스토리 조회 - 날짜",
+    @Operation(summary = "사용자의 히스토리 상세 조회",
             description = """
                     ## 사용자 날짜 별 히스토리 상세 조회
                     ### Parameters

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
@@ -13,6 +13,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth/history")
@@ -32,5 +35,19 @@ public class HistoryController {
         Slice<Post> dateThumbnailList = historyQueryService.getHistoryThumbnailList(page);
 
         return ApiResponse.onSuccess(HistoryConverter.dataHistoryThumbnailListDTO(dateThumbnailList));
+    }
+
+    @GetMapping("/detail")
+    @Operation(summary = "사용자의 히스토리 조회 - 날짜",
+            description = """
+                    ## 사용자 날짜 별 히스토리 상세 조회
+                    ### Parameters
+                    localDate [조회할 히스토리 날짜] - e.g. 2025-02-14
+                    """)
+    public ApiResponse<HistoryResponseDTO.DateHistoryPreviewListDTO> datePreviewList (@RequestParam(name = "localDate") LocalDate localDate) {
+
+        List<Post> datePreviewList = historyQueryService.getHistoryPreviewList(localDate);
+
+        return ApiResponse.onSuccess(HistoryConverter.dateHistoryPreviewListDTO(localDate, datePreviewList));
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
@@ -30,7 +30,7 @@ public class HistoryController {
                     ### Parameters
                     page [조회할 페이지 번호] - 0부터 시작, 31개씩 보여줌
                     """)
-    public ApiResponse<HistoryResponseDTO.DataHistoryThumbnailListDTO> dateThumbnailList (@RequestParam(name = "page") Integer page) {
+    public ApiResponse<HistoryResponseDTO.DataHistoryThumbnailListDTO> dateThumbnailList (@RequestParam(name = "page") Integer page) { // 히스토리 썸네일 조회
 
         Slice<Post> dateThumbnailList = historyQueryService.getHistoryThumbnailList(page);
 
@@ -44,7 +44,7 @@ public class HistoryController {
                     ### Parameters
                     localDate [조회할 히스토리 날짜] - e.g. 2025-02-14
                     """)
-    public ApiResponse<HistoryResponseDTO.DateHistoryPreviewListDTO> datePreviewList (@RequestParam(name = "localDate") LocalDate localDate) {
+    public ApiResponse<HistoryResponseDTO.DateHistoryPreviewListDTO> datePreviewList (@RequestParam(name = "localDate") LocalDate localDate) { // 히스토리 게시글 상세 조회
 
         List<Post> datePreviewList = historyQueryService.getHistoryPreviewList(localDate);
 

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
@@ -1,0 +1,36 @@
+package UMC_7th.Closit.domain.post.controller;
+
+import UMC_7th.Closit.domain.post.converter.HistoryConverter;
+import UMC_7th.Closit.domain.post.dto.HistoryResponseDTO;
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.domain.post.service.HistoryQueryService;
+import UMC_7th.Closit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/history")
+public class HistoryController {
+
+    private final HistoryQueryService historyQueryService;
+
+    @GetMapping
+    @Operation(summary = "사용자의 히스토리 조회 - 날짜",
+            description = """
+                    ## 사용자 날짜 별 히스토리 조회
+                    ### Parameters
+                    page [조회할 페이지 번호] - 0부터 시작, 31개씩 보여줌
+                    """)
+    public ApiResponse<HistoryResponseDTO.DataHistoryThumbnailListDTO> dateThumbnailList (@RequestParam(name = "page") Integer page) {
+
+        Slice<Post> dateThumbnailList = historyQueryService.getHistoryThumbnailList(page);
+
+        return ApiResponse.onSuccess(HistoryConverter.dataHistoryThumbnailListDTO(dateThumbnailList));
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/HistoryController.java
@@ -24,11 +24,11 @@ public class HistoryController {
     private final HistoryQueryService historyQueryService;
 
     @GetMapping
-    @Operation(summary = "사용자의 히스토리 썸네일 조회",
+    @Operation(summary = "사용자의 히스토리 게시글 썸네일 조회",
             description = """
-                    ## 사용자 날짜 별 히스토리 썸네일 조회
+                    ## 사용자 날짜 별 히스토리 게시글 썸네일 조회
                     ### Parameters
-                    page [조회할 페이지 번호] - 0부터 시작, 50개씩 보여줌
+                    page [조회할 페이지 번호] - 0부터 시작, 30개씩 보여줌
                     """)
     public ApiResponse<HistoryResponseDTO.DataHistoryThumbnailListDTO> dateThumbnailList (@RequestParam(name = "page") Integer page) { // 히스토리 썸네일 조회
 
@@ -56,7 +56,7 @@ public class HistoryController {
             description = """
                     ## 사용자 날짜 별 히스토리 포인트 컬러 썸네일 조회
                     ### Parameters
-                    page [조회할 페이지 번호] - 0부터 시작, 50개씩 보여줌
+                    page [조회할 페이지 번호] - 0부터 시작, 30개씩 보여줌
                     """)
     public ApiResponse<HistoryResponseDTO.ColorHistoryThumbnailListDTO> colorThumbnailList (@RequestParam(name = "page") Integer page) { // 히스토리 포인트 색상 썸네일 조회
 

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/HistoryConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/HistoryConverter.java
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 public class HistoryConverter {
 
-    public static HistoryResponseDTO.DateHistoryThumbnailDTO dateHistoryThumbnailDTO (Post post) { // 날짜 별 조회 - 썸네일
+    public static HistoryResponseDTO.DateHistoryThumbnailDTO dateHistoryThumbnailDTO (Post post) { // 히스토리 썸네일 조회
         return  HistoryResponseDTO.DateHistoryThumbnailDTO.builder()
                 .postId(post.getId())
                 .thumbnail(post.getFrontImage())

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/HistoryConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/HistoryConverter.java
@@ -1,0 +1,50 @@
+package UMC_7th.Closit.domain.post.converter;
+
+import UMC_7th.Closit.domain.post.dto.HistoryResponseDTO;
+import UMC_7th.Closit.domain.post.entity.Post;
+import org.springframework.data.domain.Slice;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HistoryConverter {
+
+    public static HistoryResponseDTO.DateHistoryThumbnailDTO dateHistoryThumbnailDTO (Post post) { // 날짜 별 조회 - 썸네일
+        return  HistoryResponseDTO.DateHistoryThumbnailDTO.builder()
+                .postId(post.getId())
+                .thumbnail(post.getFrontImage())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    public static HistoryResponseDTO.DataHistoryThumbnailListDTO dataHistoryThumbnailListDTO (Slice<Post> postList) {
+        List<HistoryResponseDTO.DateHistoryThumbnailDTO> dateHistoryThumbnailDTOList = postList.stream()
+                .map(HistoryConverter::dateHistoryThumbnailDTO).collect(Collectors.toList());
+
+        return HistoryResponseDTO.DataHistoryThumbnailListDTO.builder()
+                .dateHistoryThumbnailDTOList(dateHistoryThumbnailDTOList)
+                .listSize(dateHistoryThumbnailDTOList.size())
+                .isFirst(postList.isFirst())
+                .isLast(postList.isLast())
+                .hasNext(postList.hasNext())
+                .build();
+    }
+
+    public static HistoryResponseDTO.DateHistoryPreviewDTO dateHistoryPreviewDTO(Post post) { // 히스토리 게시글 상세 조회
+        return HistoryResponseDTO.DateHistoryPreviewDTO.builder()
+                .postId(post.getId())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    public static HistoryResponseDTO.DateHistoryPreviewListDTO dateHistoryPreviewListDTO(LocalDate localDate, List<Post> postList) {
+        List<HistoryResponseDTO.DateHistoryPreviewDTO> historyPreviewDTOList = postList.stream()
+                .map(HistoryConverter::dateHistoryPreviewDTO).collect(Collectors.toList());
+
+        return HistoryResponseDTO.DateHistoryPreviewListDTO.builder()
+                .postList(historyPreviewDTOList)
+                .date(localDate)
+                .build();
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/HistoryConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/HistoryConverter.java
@@ -47,4 +47,25 @@ public class HistoryConverter {
                 .date(localDate)
                 .build();
     }
+
+    public static HistoryResponseDTO.ColorHistoryThumbnailDTO colorHistoryThumbnailDTO(Post post) { // 히스토리 포인트 색상 썸네일 조회
+        return HistoryResponseDTO.ColorHistoryThumbnailDTO.builder()
+                .postId(post.getId())
+                .thumbnail(post.getPointColor())
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+    public static HistoryResponseDTO.ColorHistoryThumbnailListDTO colorHistoryThumbnailListDTO(Slice<Post> postList) {
+        List<HistoryResponseDTO.ColorHistoryThumbnailDTO> colorHistoryThumbnailDTOList = postList.stream()
+                .map(HistoryConverter::colorHistoryThumbnailDTO).collect(Collectors.toList());
+
+        return HistoryResponseDTO.ColorHistoryThumbnailListDTO.builder()
+                .colorHistoryThumbnailDTOList(colorHistoryThumbnailDTOList)
+                .listSize(colorHistoryThumbnailDTOList.size())
+                .isFirst(postList.isFirst())
+                .isLast(postList.isLast())
+                .hasNext(postList.hasNext())
+                .build();
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/HistoryResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/HistoryResponseDTO.java
@@ -16,7 +16,7 @@ public class HistoryResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class DateHistoryThumbnailDTO { // 날짜 별 조회 - 썸네일
+    public static class DateHistoryThumbnailDTO { // 히스토리 썸네일 조회
         private Long postId;
         private String thumbnail;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/HistoryResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/HistoryResponseDTO.java
@@ -54,4 +54,26 @@ public class HistoryResponseDTO {
         @JsonFormat(pattern = "yyyy/MM/dd")
         private LocalDate date;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ColorHistoryThumbnailDTO { // 히스토리 포인트 색상 썸네일 조회
+        private Long postId;
+        private String thumbnail;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
+        private LocalDateTime createdAt;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ColorHistoryThumbnailListDTO {
+        private List<ColorHistoryThumbnailDTO> colorHistoryThumbnailDTOList;
+        private Integer listSize;
+        private boolean isFirst;
+        private boolean isLast;
+        private boolean hasNext;
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/HistoryResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/HistoryResponseDTO.java
@@ -1,0 +1,57 @@
+package UMC_7th.Closit.domain.post.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class HistoryResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DateHistoryThumbnailDTO { // 날짜 별 조회 - 썸네일
+        private Long postId;
+        private String thumbnail;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
+        private LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DataHistoryThumbnailListDTO {
+        private List<DateHistoryThumbnailDTO> dateHistoryThumbnailDTOList;
+        private Integer listSize;
+        private boolean isFirst;
+        private boolean isLast;
+        private boolean hasNext;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DateHistoryPreviewDTO { // 히스토리 게시글 상세 조회
+        private Long postId;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
+        private LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DateHistoryPreviewListDTO {
+        private List<DateHistoryPreviewDTO> postList;
+        @JsonFormat(pattern = "yyyy/MM/dd")
+        private LocalDate date;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -32,4 +32,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Slice<Post> findFrontImageByUserId(@Param("userId") Long userId, Pageable pageable);
 
     List<Post> findAllByUserIdAndCreatedAtBetween (Long userId, LocalDateTime start, LocalDateTime end); // 히스토리 게시글 상세 조회 - 하루 내 게시글 탐색
+
+    @Query("SELECT p FROM Post p WHERE p.user.id = :userId GROUP BY FUNCTION('DATE', p.createdAt) ORDER BY p.createdAt ASC")
+    Slice<Post> findPointColorByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -29,4 +30,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p WHERE p.user.id = :userId GROUP BY FUNCTION('DATE', p.createdAt) ORDER BY p.createdAt ASC")
     Slice<Post> findFrontImageByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    List<Post> findAllByUserIdAndCreatedAtBetween (Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -28,8 +28,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-    @Query("SELECT p FROM Post p WHERE p.user.id = :userId GROUP BY FUNCTION('DATE', p.createdAt) ORDER BY p.createdAt ASC")
+    @Query("SELECT p FROM Post p WHERE p.user.id = :userId GROUP BY FUNCTION('DATE', p.createdAt) ORDER BY p.createdAt ASC") // 히스토리 썸네일 조회
     Slice<Post> findFrontImageByUserId(@Param("userId") Long userId, Pageable pageable);
 
-    List<Post> findAllByUserIdAndCreatedAtBetween (Long userId, LocalDateTime start, LocalDateTime end);
+    List<Post> findAllByUserIdAndCreatedAtBetween (Long userId, LocalDateTime start, LocalDateTime end); // 히스토리 게시글 상세 조회 - 하루 내 게시글 탐색
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -34,5 +34,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByUserIdAndCreatedAtBetween (Long userId, LocalDateTime start, LocalDateTime end); // 히스토리 게시글 상세 조회 - 하루 내 게시글 탐색
 
     @Query("SELECT p FROM Post p WHERE p.user.id = :userId GROUP BY FUNCTION('DATE', p.createdAt) ORDER BY p.createdAt ASC")
-    Slice<Post> findPointColorByUserId(@Param("userId") Long userId, Pageable pageable);
+    Slice<Post> findPointColorByUserId(@Param("userId") Long userId, Pageable pageable); // 히스토리 포인트 색상 썸네일 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -25,4 +26,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Slice<Post> findByHashtagId(Long hashtagId, Pageable pageable);
 
     Slice<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    @Query("SELECT p FROM Post p WHERE p.user.id = :userId GROUP BY FUNCTION('DATE', p.createdAt) ORDER BY p.createdAt ASC")
+    Slice<Post> findFrontImageByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
@@ -7,6 +7,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface HistoryQueryService {
-    Slice<Post> getHistoryThumbnailList(Integer page); // 날짜 별 조회 - 썸네일
+    Slice<Post> getHistoryThumbnailList(Integer page); // 히스토리 썸네일 조회
     List<Post> getHistoryPreviewList(LocalDate localDate); // 히스토리 게시글 상세 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
@@ -1,0 +1,8 @@
+package UMC_7th.Closit.domain.post.service;
+
+import UMC_7th.Closit.domain.post.entity.Post;
+import org.springframework.data.domain.Slice;
+
+public interface HistoryQueryService {
+    Slice<Post> getHistoryThumbnailList(Integer page); // 날짜 별 조회 - 썸네일
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface HistoryQueryService {
     Slice<Post> getHistoryThumbnailList(Integer page); // 히스토리 썸네일 조회
     List<Post> getHistoryPreviewList(LocalDate localDate); // 히스토리 게시글 상세 조회
+    Slice<Post> getHistoryColorThumbnailList(Integer page); // 히스토리 포인트 색상 썸네일 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryService.java
@@ -3,6 +3,10 @@ package UMC_7th.Closit.domain.post.service;
 import UMC_7th.Closit.domain.post.entity.Post;
 import org.springframework.data.domain.Slice;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface HistoryQueryService {
     Slice<Post> getHistoryThumbnailList(Integer page); // 날짜 별 조회 - 썸네일
+    List<Post> getHistoryPreviewList(LocalDate localDate); // 히스토리 게시글 상세 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
@@ -29,7 +29,7 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 
-        Pageable pageable = PageRequest.of(page, 31);
+        Pageable pageable = PageRequest.of(page, 50);
 
         Slice<Post> postList = postRepository.findFrontImageByUserId(userId, pageable);
 
@@ -45,5 +45,17 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
         LocalDateTime end = start.plusDays(1);
 
         return postRepository.findAllByUserIdAndCreatedAtBetween(userId, start, end);
+    }
+
+    @Override
+    public Slice<Post> getHistoryColorThumbnailList(Integer page) { // 히스토리 포인트 색상 썸네일 조회
+        User user = securityUtil.getCurrentUser();
+        Long userId = user.getId();
+
+        Pageable pageable = PageRequest.of(page, 50);
+
+        Slice<Post> postList = postRepository.findPointColorByUserId(userId, pageable);
+
+        return postList;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
@@ -11,6 +11,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
 
 @Service
 @Transactional(readOnly = true)
@@ -30,5 +34,16 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
         Slice<Post> postList = postRepository.findFrontImageByUserId(userId, pageable);
 
         return postList;
+    }
+
+    @Override
+    public List<Post> getHistoryPreviewList(LocalDate localDate) { // 히스토리 게시글 상세 조회
+        User user = securityUtil.getCurrentUser();
+        Long userId = user.getId();
+
+        LocalDateTime start = localDate.atStartOfDay();
+        LocalDateTime end = start.plusDays(1);
+
+        return postRepository.findAllByUserIdAndCreatedAtBetween(userId, start, end);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
@@ -25,7 +25,7 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
     private final SecurityUtil securityUtil;
 
     @Override
-    public Slice<Post> getHistoryThumbnailList (Integer page) { // 날짜 별 조회 - 썸네일
+    public Slice<Post> getHistoryThumbnailList (Integer page) { // 히스토리 썸네일 조회
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
@@ -1,0 +1,34 @@
+package UMC_7th.Closit.domain.post.service;
+
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.domain.post.repository.PostRepository;
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class HistoryQueryServiceImpl implements HistoryQueryService{
+
+    private final PostRepository postRepository;
+    private final SecurityUtil securityUtil;
+
+    @Override
+    public Slice<Post> getHistoryThumbnailList (Integer page) { // 날짜 별 조회 - 썸네일
+        User user = securityUtil.getCurrentUser();
+        Long userId = user.getId();
+
+        Pageable pageable = PageRequest.of(page, 31);
+
+        Slice<Post> postList = postRepository.findFrontImageByUserId(userId, pageable);
+
+        return postList;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/HistoryQueryServiceImpl.java
@@ -29,7 +29,7 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 
-        Pageable pageable = PageRequest.of(page, 50);
+        Pageable pageable = PageRequest.of(page, 30);
 
         Slice<Post> postList = postRepository.findFrontImageByUserId(userId, pageable);
 
@@ -52,7 +52,7 @@ public class HistoryQueryServiceImpl implements HistoryQueryService{
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 
-        Pageable pageable = PageRequest.of(page, 50);
+        Pageable pageable = PageRequest.of(page, 30);
 
         Slice<Post> postList = postRepository.findPointColorByUserId(userId, pageable);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #80 #38 feat: 사용자 history 조회 API

## 📝작업 내용

> 히스토리 게시글 썸네일 조회
히스토리 포인트 컬러 썸네일 조회
히스토리 상세 조회

## 스크린샷 (선택)
> 히스토리 게시글 썸네일 조회 (하루 중 맨 처음 올렸던 게시글의 fromtImage가 썸네일로)
![스크린샷 2025-02-14 140217](https://github.com/user-attachments/assets/b1dd39c6-eb88-42c9-b322-d2d4c5f4f1b5)

> 히스토리 포인트 컬러 썸네일 조회 (하루 중 맨 처음 올렸던 게시글의 pointColor가 썸네일로)
![스크린샷 2025-02-14 140239](https://github.com/user-attachments/assets/82848248-0af4-4e27-a21d-4ff6f52f7ec3)

> 히스토리 상세 조회
![스크린샷 2025-02-14 140312](https://github.com/user-attachments/assets/0aba9345-a511-448b-9406-66d67ed1d7a2)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
