### PR TITLE
#39 refactor: 배틀 조회 API 수정 

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
@@ -29,8 +29,8 @@ public class BattleCommentConverter {
 
     public static BattleCommentResponseDTO.BattleCommentPreviewDTO battleCommentPreviewDTO (BattleComment battleComment) { // 배틀 댓글 조회
         return BattleCommentResponseDTO.BattleCommentPreviewDTO.builder()
-                .clositId(battleComment.getUser().getClositId())
                 .battleCommentId(battleComment.getId())
+                .clositId(battleComment.getUser().getClositId())
                 .content(battleComment.getContent())
                 .createdAt(battleComment.getCreatedAt())
                 .build();

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -57,6 +57,7 @@ public class BattleConverter {
 
     public static BattleResponseDTO.BattlePreviewDTO battlePreviewDTO(Battle battle) { // 배틀 게시글 목록 조회
         return BattleResponseDTO.BattlePreviewDTO.builder()
+                .battleId(battle.getId())
                 .title(battle.getTitle())
                 .firstClositId(battle.getPost1().getUser().getClositId())
                 .firstPostId(battle.getPost1().getId())
@@ -82,6 +83,7 @@ public class BattleConverter {
 
     public static BattleResponseDTO.ChallengeBattlePreviewDTO challengeBattlePreviewDTO(Battle battle) { // 배틀 챌린지 게시글 목록 조회
         return BattleResponseDTO.ChallengeBattlePreviewDTO.builder()
+                .battleId(battle.getId())
                 .firstClositId(battle.getPost1().getUser().getClositId())
                 .firstPostId(battle.getPost1().getId())
                 .title(battle.getTitle())

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleLikeConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleLikeConverter.java
@@ -28,8 +28,8 @@ public class BattleLikeConverter {
 
     public static BattleLikeResponseDTO.BattleLikePreviewDTO battleLikePreviewDTO (BattleLike battleLike) { // 배틀 좋아요 조회
         return BattleLikeResponseDTO.BattleLikePreviewDTO.builder()
-                .clositId(battleLike.getUser().getClositId())
                 .battleLikeId(battleLike.getId())
+                .clositId(battleLike.getUser().getClositId())
                 .createdAt(battleLike.getCreatedAt())
                 .build();
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
@@ -26,8 +26,8 @@ public class BattleCommentResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BattleCommentPreviewDTO { // 배틀 댓글 조회
-        private String clositId;
         private Long battleCommentId;
+        private String clositId;
         private String content;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -56,6 +56,7 @@ public class BattleResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BattlePreviewDTO { // 배틀 게시글 목록 조회
+        private Long battleId;
         private String title;
         private String firstClositId;
         private Long firstPostId;
@@ -82,6 +83,7 @@ public class BattleResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChallengeBattlePreviewDTO { // 배틀 챌린지 게시글 목록 조회
+        private Long battleId;
         private String firstClositId;
         private Long firstPostId;
         private String title;

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleLikeDTO/BattleLikeResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleLikeDTO/BattleLikeResponseDTO.java
@@ -26,8 +26,8 @@ public class BattleLikeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BattleLikePreviewDTO { // 배틀 좋아요 조회
-        private String clositId;
         private Long battleLikeId;
+        private String clositId;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #82 #39 refactor: 배틀 조회 API 수정 

## 📝작업 내용

> 배틀 게시글 목록 조회 response에 battleId값 추가
배틀 챌린지 게시글 목록 조회 response에 battleId값 추가

## 스크린샷 (선택)
> 배틀 게시글 목록 조회 response에 battleId값 추가
![image](https://github.com/user-attachments/assets/031e355c-ce1d-4aae-9ab0-bf620487d9ee)

> 배틀 챌린지 게시글 목록 조회 response에 battleId값 추가
![image](https://github.com/user-attachments/assets/fb10f206-ac0a-4c6c-90fd-d467090632fb)

## 💬리뷰 요구사항(선택)

> 큰 수정 사항은 없어서 확인 후 바로 머지하면 될 것 같습니다.
