### PR TITLE
#40 fix: 알림 관련 API 수정 

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/notification/controller/NotificationController.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/controller/NotificationController.java
@@ -56,7 +56,7 @@ public class NotificationController {
         return ApiResponse.onSuccess(NotificationConverter.notiPreviewDTO(notification));
     }
 
-    @GetMapping()
+    @PatchMapping()
     @Operation(summary = "알림 목록 조회",
             description = """
              ## 특정 사용자의 알림 목록 조회 (최신 순 정렬)

--- a/src/main/java/UMC_7th/Closit/domain/notification/controller/NotificationController.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/controller/NotificationController.java
@@ -59,7 +59,7 @@ public class NotificationController {
     @PatchMapping()
     @Operation(summary = "알림 목록 조회",
             description = """
-             ## 특정 사용자의 알림 목록 조회 (최신 순 정렬)
+             ## 특정 사용자의 알림 목록 조회 후 읽음 처리 (최신 순 정렬)
              ### Parameters
              page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌
              """)

--- a/src/main/java/UMC_7th/Closit/domain/notification/controller/NotificationController.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/controller/NotificationController.java
@@ -51,7 +51,7 @@ public class NotificationController {
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 
-        Notification notification = notiCommandService.readNotification(userId, notification_id);
+        Notification notification = notiQueryService.readNotification(userId, notification_id);
 
         return ApiResponse.onSuccess(NotificationConverter.notiPreviewDTO(notification));
     }

--- a/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
@@ -40,6 +40,8 @@ public class NotificationConverter {
 
     public static NotificationResponseDTO.NotiPreviewDTO notiPreviewDTO (Notification notification) { // 알림 단건 조회
         return NotificationResponseDTO.NotiPreviewDTO.builder()
+                .notificationId(notification.getId())
+                .clositId(notification.getUser().getClositId())
                 .userName(notification.getUser().getName())
                 .imageUrl(notification.getUser().getProfileImage())
                 .content(notification.getContent())

--- a/src/main/java/UMC_7th/Closit/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/dto/NotificationResponseDTO.java
@@ -30,6 +30,8 @@ public class NotificationResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class NotiPreviewDTO { // 알림 단건 조회
+        private Long notificationId;
+        private String clositId;
         private String userName;
         private String imageUrl;
         private String content;

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandService.java
@@ -17,6 +17,5 @@ public interface NotiCommandService {
     void likeNotification(Likes likes); // 좋아요 알림
     void followNotification(Follow follow); // 팔로우 알림
     void missionNotification(SseEmitter emitter, String emitterId, Object data); // 미션 알림
-    Notification readNotification(Long userId, Long notificationId); // 알람 단건 조회 - 읽음 처리
     void deleteNotification(Long userId, Long notificationId); // 알림 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -127,8 +127,8 @@ public class NotiCommandServiceImpl implements NotiCommandService {
 
     @Override
     public void followNotification(Follow follow) { // 팔로우 알림
-        User receiver = follow.getFollowing(); // 팔로잉
-        String content = follow.getFollower().getName() + "님이 회원님을 팔로우하기 시작했습니다. ";
+        User receiver = follow.getFollower(); // 팔로워 알림 받는 사용자
+        String content = follow.getFollowing().getName() + "님이 회원님을 팔로우하기 시작했습니다. ";
 
         NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, NotificationType.FOLLOW);
 

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -155,17 +155,6 @@ public class NotiCommandServiceImpl implements NotiCommandService {
     }
 
     @Override
-    public Notification readNotification(Long userId, Long notificationId) { // 알림 단건 조회 - 읽음 처리
-        Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
-
-        // 읽음 처리
-        notification.markAsRead();
-
-        return notificationRepository.save(notification);
-    }
-
-    @Override
     public void deleteNotification(Long userId, Long notificationId) { // 알림 삭제
         notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiQueryService.java
@@ -4,5 +4,6 @@ import UMC_7th.Closit.domain.notification.entity.Notification;
 import org.springframework.data.domain.Slice;
 
 public interface NotiQueryService {
-    Slice<Notification> getNotificationList (Long userId, Integer page);
+    Notification readNotification(Long userId, Long notificationId); // 알림 단건 조회 - 읽음 처리
+    Slice<Notification> getNotificationList (Long userId, Integer page); // 알림 목록 조회 - 읽음 처리
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiQueryServiceImpl.java
@@ -22,7 +22,18 @@ public class NotiQueryServiceImpl implements NotiQueryService {
     private final NotificationRepository notificationRepository;
 
     @Override
-    public Slice<Notification> getNotificationList(Long userId, Integer page) { // 알림 목록 조회
+    public Notification readNotification(Long userId, Long notificationId) { // 알림 단건 조회 - 읽음 처리
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        // 읽음 처리
+        notification.markAsRead();
+
+        return notificationRepository.save(notification);
+    }
+
+    @Override
+    public Slice<Notification> getNotificationList(Long userId, Integer page) { // 알림 목록 조회 - 읽음 처리
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiQueryServiceImpl.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class NotiQueryServiceImpl implements NotiQueryService {
 
@@ -30,6 +30,12 @@ public class NotiQueryServiceImpl implements NotiQueryService {
 
         // 최신순으로 조회
         Slice<Notification> notificationList = notificationRepository.findByUserOrderByCreatedAtDesc(user, pageable);
+
+        // 전체 알림 읽음 처리
+        notificationList.forEach(notification -> {
+            notification.markAsRead();
+            notificationRepository.save(notification);
+        });
 
         return notificationList;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #85 #40 fix: 알림 관련 API 수정

## 📝작업 내용

> response 값 수정
팔로우 알림 수정
알림 전체 조회 후 읽음 처리

## 스크린샷 (선택)
> response 값 수정
![image](https://github.com/user-attachments/assets/402f858c-af10-41f6-a4a8-e9f4b4936232)
![image](https://github.com/user-attachments/assets/d32181d0-a0a8-4e65-b41f-66fb6e4e3c2a)

> 알림 전체 조회 후 읽음 처리
![image](https://github.com/user-attachments/assets/9231457d-7358-4c22-aa90-8edf33351522)

## 💬리뷰 요구사항(선택)

> 알림 단건 조회는 추후 해당 게시글 or 팔로워로 이동하는 링크를 추가할 수도 있어서 일단 남겨 놓았습니다. 
