### PR TITLE
#43 feat: 사용자 정보 수정 API 구현

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -3,12 +3,14 @@ package UMC_7th.Closit.domain.user.controller;
 import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.mission.entity.Mission;
 import UMC_7th.Closit.domain.user.converter.UserConverter;
+import UMC_7th.Closit.domain.user.dto.UserRequestDTO;
 import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
 import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.service.UserCommandService;
 import UMC_7th.Closit.domain.user.service.UserQueryService;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -35,6 +37,15 @@ public class UserController {
 
         userCommandService.deleteUser();
         return ApiResponse.onSuccess("Deletion successful");
+    }
+
+    @Operation(summary = "사용자 정보 수정", description = "사용자 정보를 수정합니다.")
+    @PatchMapping("/")
+    public ApiResponse<UserResponseDTO.UserInfoDTO> updateUserInfo(@Valid @RequestBody UserRequestDTO.UpdateUserDTO updateUserDTO) {
+
+        User userInfo = userCommandService.updateUserInfo(updateUserDTO);
+
+        return ApiResponse.onSuccess(UserConverter.toUserInfoDTO(userInfo));
     }
 
     @Operation(summary = "사용자 프로필 이미지 등록", description = "특정 사용자의 프로필 이미지를 등록합니다.")

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserRequestDTO.java
@@ -1,8 +1,8 @@
 package UMC_7th.Closit.domain.user.dto;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
+import UMC_7th.Closit.global.validation.annotation.ExistUserClositId;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -13,6 +13,7 @@ public class UserRequestDTO {
     @AllArgsConstructor
     public static class CreateUserDTO {
         @NotBlank(message = "이름은 필수 입력 값입니다.")
+        @Size(min = 2, max = 20, message = "이름은 2~20자 사이여야 합니다.")
         private String name;
 
         @NotBlank(message = "이메일은 필수 입력 값입니다.")
@@ -23,10 +24,34 @@ public class UserRequestDTO {
         @Size(min = 8, message = "비밀번호는 최소 8자리 이상이어야 합니다.")
         private String password;
 
+        @NotBlank(message = "clositId는 필수 입력 값입니다.")
+        @Size(min = 2, max = 20, message = "clositId는 2~20자 사이여야 합니다.")
         private String clositId;
 
+        @PastOrPresent(message = "생년월일은 과거나 현재 날짜여야 합니다.")
         private LocalDate birth;
 
         private String profileImage;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL) // null 값은 JSON 변환 시 제외
+    public static class UpdateUserDTO {
+
+        @Size(min = 2, max = 20, message = "이름은 2~20자 사이여야 합니다.")
+        private String name;
+
+        @Size(min = 2, max = 20, message = "clositId는 2~20자 사이여야 합니다.")
+        private String clositId;
+
+        @NotBlank(message = "현재 비밀번호는 필수 입력 값입니다.")
+        private String currentPassword;
+
+        @Size(min = 8, message = "비밀번호는 최소 8자리 이상이어야 합니다.")
+        private String password;
+
+        @PastOrPresent(message = "생년월일은 과거나 현재 날짜여야 합니다.")
+        private LocalDate birth;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -13,6 +13,10 @@ import UMC_7th.Closit.domain.post.entity.Likes;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.global.common.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -109,5 +113,21 @@ public class User extends BaseEntity {
     public User updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
         return this;
+    }
+
+    public void setName(@Size(min = 2, max = 20, message = "이름은 2~20자 사이여야 합니다.") String name) {
+        this.name = name;
+    }
+
+    public void setClositId(@Size(min = 2, max = 20, message = "clositId는 2~20자 사이여야 합니다.") String clositId) {
+        this.clositId = clositId;
+    }
+
+    public void setPassword(String encode) {
+        this.password = encode;
+    }
+
+    public void setBirth(@PastOrPresent(message = "생년월일은 과거나 현재 날짜여야 합니다.") LocalDate birth) {
+        this.birth = birth;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
@@ -14,4 +14,6 @@ public interface UserCommandService {
     User registerProfileImage (MultipartFile file);
 
     boolean isClositIdUnique(String clositId);
+
+    User updateUserInfo(UserRequestDTO.UpdateUserDTO updateUserDTO);
 }

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -26,6 +26,8 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4005","이미 존재하는 이메일입니다"), // 리소스 충돌
     USER_NOT_FOUND (HttpStatus.NOT_FOUND, "USER4006", "사용자가 존재하지 않습니다."), // 존재하지 않는 사용자
     CLOSIT_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "USER4007", "이미 존재하는 ClositId입니다."), // 리소스 충돌
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER4008", "비밀번호가 유효하지 않습니다."), // 비밀번호 유효성 검사 실패
+    NO_CHANGE_DETECTED(HttpStatus.BAD_REQUEST, "USER4009", "변경된 내용이 없습니다."), // 변경된 내용이 없음
 
     // 토큰 관련 에러
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

#92 

## 📝작업 내용

- 사용자 정보 수정 기능 구현 (updateUserInfo)
사용자가 제공한 정보(name, clositId, password, birth)만 업데이트
변경 사항이 없을 경우 예외(NO_CHANGE_DETECTED) 발생
clositId가 중복되면 예외(CLOSIT_ID_ALREADY_EXISTS) 발생
현재 비밀번호 검증 후 비밀번호 변경 가능 (INVALID_PASSWORD 예외 처리)
UpdateUserDTO 유효성 검증 추가

- currentPassword 필수 (@NotBlank)
name, clositId, password, birth는 선택적 수정 가능
birth 필드는 과거나 현재 날짜만 허용 (@PastOrPresent)

- 예외 처리 추가
INVALID_PASSWORD: 현재 비밀번호 불일치 시 예외 발생
NO_CHANGE_DETECTED: 수정할 데이터가 없을 경우 예외 발생

### 스크린샷 (선택)
1. 현재 비밀번호 변경 없이 요청
![image](https://github.com/user-attachments/assets/663f88cf-cd90-482f-aee0-4b22d7dddffc)

2. 수정 사항 없이 요청
![image](https://github.com/user-attachments/assets/d0514230-f4fb-4b42-836f-088f88b8327d)

3. 잘못된 생년월일 입력
![image](https://github.com/user-attachments/assets/62a254dc-7987-433b-860d-ec8691f59ee3)

4. 모든 정보를 변경하는 경우
![image](https://github.com/user-attachments/assets/35bc3653-0045-4df3-a830-60c780665b55)

5. 이미 존재하는 clositId로 요청
![image](https://github.com/user-attachments/assets/ac368b44-72b8-4e9b-a1d7-d05f011f0d28)

6. 비밀번호만 변경
![image](https://github.com/user-attachments/assets/65648964-a669-490a-8192-f5507c355340)

7. 이름만 변경
![image](https://github.com/user-attachments/assets/a199a121-3333-42bc-99b7-fbcb2dd67664)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
