### PR TITLE
#46 fix: 댓글 관련 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -136,6 +136,11 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         Battle battle = battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 
+        // 배틀 게시글을 생성한 이가 아닐 경우 , 삭제 불가능
+        if (!battle.getPost1().getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.POST_NOT_MINE);
+        }
+
         battleRepository.delete(battle);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
-    private final SecurityUtil securityUtil;
 
     @Operation(summary = "새로운 댓글 생성")
     @PostMapping

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
@@ -22,8 +22,15 @@ public class CommentController {
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
 
-    @Operation(summary = "새로운 댓글 생성")
     @PostMapping
+    @Operation(summary = "새로운 댓글 생성",
+            description = """
+            ## 게시글 내 새로운 댓글 작성
+            ### PathVariable
+            post_id [게시글 ID] \n
+            ### RequestBody
+            content [댓글 내용]
+            """)
     public ApiResponse<CommentResponseDTO.CreateCommentResultDTO> createComment(
             @RequestBody @Valid CommentRequestDTO.CreateCommentRequestDTO request,
             @PathVariable("post_id") Long postId) {
@@ -33,8 +40,15 @@ public class CommentController {
         return ApiResponse.onSuccess(CommentConverter.createCommentResponseDTO(comment));
     }
 
-    @Operation(summary = "댓글 조회")
     @GetMapping
+    @Operation(summary = "댓글 조회",
+            description = """
+            ## 게시글 내 댓글 목록 조회
+            ### PathVariable
+            post_id [게시글 ID] \n
+            ### RequestParam
+            page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌
+            """)
     public ApiResponse<CommentResponseDTO.CommentPreviewListDTO> getComments(
             @PathVariable("post_id") Long postId,
             @RequestParam(name = "page") Integer page) {
@@ -44,7 +58,13 @@ public class CommentController {
         return ApiResponse.onSuccess(CommentConverter.commentPreviewListDTO(commentList));
     }
 
-    @Operation(summary = "댓글 삭제")
+    @Operation(summary = "댓글 삭제",
+            description = """
+            ## 게시글 내 특정 댓글 삭제
+            ### PathVariable
+            post_id [게시글 ID] \n
+            comment_id [댓글 ID]
+            """)
     @DeleteMapping("/{comment_id}")
     public ApiResponse<String> deleteComment(
             @PathVariable("post_id") Long postId,

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
@@ -6,7 +6,9 @@ import UMC_7th.Closit.domain.post.dto.CommentResponseDTO;
 import UMC_7th.Closit.domain.post.entity.Comment;
 import UMC_7th.Closit.domain.post.service.CommentCommandService;
 import UMC_7th.Closit.domain.post.service.CommentQueryService;
+import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
+import UMC_7th.Closit.security.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
+    private final SecurityUtil securityUtil;
 
     @Operation(summary = "새로운 댓글 생성")
     @PostMapping

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth/posts/{post_id}/comments")
 public class CommentController {
+
     private final CommentCommandService commentCommandService;
     private final CommentQueryService commentQueryService;
 
@@ -58,6 +59,7 @@ public class CommentController {
         return ApiResponse.onSuccess(CommentConverter.commentPreviewListDTO(commentList));
     }
 
+    @DeleteMapping("/{comment_id}")
     @Operation(summary = "댓글 삭제",
             description = """
             ## 게시글 내 특정 댓글 삭제
@@ -65,7 +67,6 @@ public class CommentController {
             post_id [게시글 ID] \n
             comment_id [댓글 ID]
             """)
-    @DeleteMapping("/{comment_id}")
     public ApiResponse<String> deleteComment(
             @PathVariable("post_id") Long postId,
             @PathVariable("comment_id") Long commentId) {

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/CommentConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/CommentConverter.java
@@ -23,14 +23,15 @@ public class CommentConverter {
     public static CommentResponseDTO.CreateCommentResultDTO createCommentResponseDTO(Comment comment) {
         return CommentResponseDTO.CreateCommentResultDTO.builder()
                 .commentId(comment.getId())
+                .clositId(comment.getUser().getClositId())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }
 
     public static CommentResponseDTO.CommentPreviewDTO commentPreviewDTO(Comment comment) {
         return CommentResponseDTO.CommentPreviewDTO.builder()
-                .userId(comment.getUser().getId())
                 .commentId(comment.getId())
+                .clositId(comment.getUser().getClositId())
                 .content(comment.getContent())
                 .createdAt(comment.getCreatedAt())
                 .build();

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/CommentRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/CommentRequestDTO.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 public class CommentRequestDTO {
     @Getter
     public static class CreateCommentRequestDTO{
-        @NotNull
-        private Long userId;
         @NotBlank
         private String content;
     }

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/CommentResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/CommentResponseDTO.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,8 @@ public class CommentResponseDTO {
     @AllArgsConstructor
     public static class CreateCommentResultDTO { // 댓글 생성 응답
         private Long commentId;
+        private String clositId;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
 
@@ -23,9 +26,10 @@ public class CommentResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class CommentPreviewDTO { // 댓글 조회
-        private Long userId;
+        private String clositId;
         private Long commentId;
         private String content;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CommentCommandServiceImpl implements CommentCommandService {
 
-    private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final NotiCommandService notiCommandService;

--- a/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
@@ -11,6 +11,7 @@ import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
+import UMC_7th.Closit.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,17 +23,16 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
-
     private final NotiCommandService notiCommandService;
+    private final SecurityUtil securityUtil;
 
     @Override
     @Transactional
     public Comment createComment(Long postId, CommentRequestDTO.CreateCommentRequestDTO request) {
-        User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        User user = securityUtil.getCurrentUser();
 
         Comment comment = CommentConverter.toComment(user, post, request);
 

--- a/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
@@ -50,6 +50,14 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
 
+        User user = securityUtil.getCurrentUser();
+        Long userId = user.getId();
+
+        // 본인의 댓글이 아닐 경우, 댓글 삭제 불가능
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.COMMENT_NOT_MINE);
+        }
+
         commentRepository.delete(comment);
     }
 }

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -46,6 +46,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 댓글 관련 에러
     COMMENT_NOT_FOUND (HttpStatus.NOT_FOUND, "COMMENT4041", "댓글이 존재하지 않습니다."),
+    COMMENT_NOT_MINE (HttpStatus.BAD_REQUEST, "COMMENT4002", "해당 댓글은 다른 사용자의 댓글입니다"),
 
     // 배틀 관련 에러
     BATTLE_NOT_CHALLENGE (HttpStatus.BAD_REQUEST, "BATTLE4001", "동일한 게시글로 배틀을 신청할 수 없습니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈

> #96 #46 fix: 댓글 관련 API 수정

## 📝작업 내용

> request userId 삭제
response userId -> clositId 수정
댓글 삭제 본인만 가능하게 수정

## 스크린샷 (선택)
> request userId 삭제
![image](https://github.com/user-attachments/assets/293140a4-a07d-4a6b-8281-7dd231e2276f)

> response userId -> clositId 수정
![image](https://github.com/user-attachments/assets/3edb783b-843c-4428-a792-18ba366682f2)

> 댓글 삭제 본인만 가능하게 수정
![image](https://github.com/user-attachments/assets/a5c1b020-c898-402e-af05-8c33fe7d8c09)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
