### PR TITLE
#44 fix: 미션 알림 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandService.java
@@ -16,6 +16,6 @@ public interface NotiCommandService {
     void commentNotification(Comment comment); // 댓글 알림
     void likeNotification(Likes likes); // 좋아요 알림
     void followNotification(Follow follow); // 팔로우 알림
-    // void missionNotification(SseEmitter emitter, String emitterId, Object data); // 미션 알림
+    void missionNotification(SseEmitter emitter, String emitterId, Object data); // 미션 알림
     void deleteNotification(Long userId, Long notificationId); // 알림 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -141,13 +142,14 @@ public class NotiCommandServiceImpl implements NotiCommandService {
 
         List<Post> posts = postRepository.findByUserId(receiver.getId());
 
-        // 24시간 이내에 사용자가 올린 게시물이 있는지 확인
+        // 하루 이내에 사용자가 올린 게시물이 있는지 확인
+        LocalDateTime today = LocalDateTime.now().with(LocalTime.MIDNIGHT);
         boolean existsPost = posts.stream()
-                .anyMatch(post -> post.getCreatedAt().isAfter(LocalDateTime.now().minusDays(1)));
+                .anyMatch(post -> post.getCreatedAt().isAfter(today));
 
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
         scheduler.schedule(() -> {
-            // 24시간 이내 사용자가 올린 게시글이 없을 경우, 알림 전송
+            // 하루 이내 사용자가 올린 게시글이 없을 경우, 알림 전송
             if (!existsPost) {
                 sendToClient(emitter, emitterId, content.getBytes(StandardCharsets.UTF_8));
             } scheduler.shutdown(); // 작업 완료 후, 스레드 종료

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -9,6 +9,8 @@ import UMC_7th.Closit.domain.notification.repository.NotificationRepository;
 import UMC_7th.Closit.domain.notification.repository.EmitterRepository;
 import UMC_7th.Closit.domain.post.entity.Comment;
 import UMC_7th.Closit.domain.post.entity.Likes;
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.domain.post.repository.PostRepository;
 import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
@@ -34,6 +36,7 @@ import java.util.concurrent.TimeUnit;
 public class NotiCommandServiceImpl implements NotiCommandService {
 
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
     private final NotificationRepository notificationRepository;
     private final EmitterRepository emitterRepository;
     private final SecurityUtil securityUtil;
@@ -60,7 +63,7 @@ public class NotiCommandServiceImpl implements NotiCommandService {
                     .forEach(entry -> sendToClient(emitter, entry.getKey(), entry.getValue()));
         }
         // 미션 알림
-        // missionNotification(emitter, emitterId, "MISSION");
+        missionNotification(emitter, emitterId, "MISSION");
 
         return emitter;
     }
@@ -131,24 +134,31 @@ public class NotiCommandServiceImpl implements NotiCommandService {
         sendNotification(request);
     }
 
-//    @Override
-//    public void missionNotification(SseEmitter emitter, String emitterId, Object data) { // 미션 알림
-//        User receiver = securityUtil.getCurrentUser(); // 현재 로그인한 사용자
-//        String content = receiver.getName() + "님 오늘의 미션을 수행해주세요!";
-//
-//        List<Mission> missions = missionRepository.findByUserId(receiver.getId());
-//
-//        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-//        scheduler.schedule(() -> {
-//            for (Mission mission : missions) {
-//                // 24시간 이내 미완료일 경우, 알림 전송
-//                if (mission.getStatus().equals(MissionStatus.INCOMPLETE) && mission.getCreatedAt().plusDays(1).isAfter(LocalDateTime.now())) {
-//                    sendToClient(emitter, emitterId, content.getBytes(StandardCharsets.UTF_8));
-//                }
-//            }
-//            scheduler.shutdown(); // 작업 완료 후, 스레드 종료
-//        }, 10, TimeUnit.SECONDS); // SSE 연결 10초 후, 한 번만 실행
-//    }
+    @Override
+    public void missionNotification(SseEmitter emitter, String emitterId, Object data) { // 미션 알림
+        User receiver = securityUtil.getCurrentUser(); // 현재 로그인한 사용자
+        String content = receiver.getName() + "님 오늘의 미션을 수행해주세요!";
+
+        List<Post> posts = postRepository.findByUserId(receiver.getId());
+
+        // 미리 미션 여부 체크
+        boolean postIsMission = posts.stream()
+                .anyMatch(post -> post.isMission() && post.getCreatedAt().plusDays(1).isAfter(LocalDateTime.now()));
+
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        scheduler.schedule(() -> {
+            // 24시간 내 isMission = true가 없을 때만 실행
+            if (!postIsMission) {
+                for (Post post : posts) {
+                    // 24시간 이내 올린 게시글이 없을 경우, 알림 전송
+                    if (!post.isMission() && post.getCreatedAt().plusDays(1).isAfter(LocalDateTime.now())) {
+                        sendToClient(emitter, emitterId, content.getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+                scheduler.shutdown(); // 작업 완료 후, 스레드 종료
+            }
+        }, 10, TimeUnit.SECONDS); // SSE 연결 10초 후, 한 번만 실행
+    }
 
     @Override
     public void deleteNotification(Long userId, Long notificationId) { // 알림 삭제

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Post.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Post.java
@@ -36,7 +36,7 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private String pointColor;
 
-    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    @Column(nullable = false)
     private boolean isMission;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -28,6 +28,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Slice<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
+    List<Post> findByUserId(Long userId); // 미션 알림
+
     @Query("SELECT p FROM Post p WHERE p.user.id = :userId GROUP BY FUNCTION('DATE', p.createdAt) ORDER BY p.createdAt ASC") // 히스토리 썸네일 조회
     Slice<Post> findFrontImageByUserId(@Param("userId") Long userId, Pageable pageable);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #94 #44 fix: 미션 알림 API 수정

## 📝작업 내용

> 24시간 내 올린 게시글이 없을 경우 미션 알림 전송

## 스크린샷 (선택)
> 주정빈일 경우 이미 올렸으므로 알림 안 옴 
![image](https://github.com/user-attachments/assets/f142300d-77d3-4e8c-b838-4630e936d5da)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
