### PR TITLE
#45 fix: 팔로우 관련 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/follow/controller/FollowController.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/controller/FollowController.java
@@ -26,17 +26,15 @@ public class FollowController {
     }
 
     @Operation(summary = "팔로우 여부 조회", description = "특정 유저를 팔로우하는지 여부를 조회합니다.")
-    @GetMapping("/{follower_closit_id}/{following_closit_id}")
-    public ApiResponse<Boolean> checkFollow(@PathVariable String follower_closit_id) {
-        return ApiResponse.onSuccess(followCommandService.isFollowing(follower_closit_id));
+    @GetMapping("/{receiver_closit_id}")
+    public ApiResponse<Boolean> checkFollow(@PathVariable String receiver_closit_id) {
+        return ApiResponse.onSuccess(followCommandService.isFollowing(receiver_closit_id));
     }
 
     @Operation(summary = "팔로우 삭제", description = "특정 팔로우를 삭제합니다.")
-    @DeleteMapping("/{follower_closit_id}/{following_closit_id}")
-    public ApiResponse<String> deleteFollow(
-            @PathVariable String follower_closit_id,
-            @PathVariable String following_closit_id ) {
-        followCommandService.deleteFollow(follower_closit_id, following_closit_id);
-        return ApiResponse.onSuccess("Deleted Follow with follower closit ID: " + follower_closit_id + ", following closit ID: " + following_closit_id);
+    @DeleteMapping("/{receiver_closit_id}")
+    public ApiResponse<String> deleteFollow(@PathVariable String receiver_closit_id) {
+        followCommandService.deleteFollow(receiver_closit_id);
+        return ApiResponse.onSuccess("Deleted Follow with receiver closit ID: " + receiver_closit_id);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/follow/converter/FollowConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/converter/FollowConverter.java
@@ -12,8 +12,8 @@ public class FollowConverter {
     public static FollowResponseDTO.CreateFollowResultDTO toCreateFollowResultDTO(Follow follow) {
         return FollowResponseDTO.CreateFollowResultDTO.builder()
                 .followId(follow.getId())
-                .followerId(follow.getFollower().getId())
-                .followingId(follow.getFollowing().getId())
+                .senderId(follow.getSender().getId())
+                .receiverId(follow.getReceiver().getId())
                 .createdAt(LocalDateTime.now())
                 .build();
     }
@@ -21,17 +21,17 @@ public class FollowConverter {
     public static FollowResponseDTO.FollowDTO toFollowDTO(Follow follow) {
         return FollowResponseDTO.FollowDTO.builder()
                 .followId(follow.getId())
-                .followerId(follow.getFollower().getId())
-                .followingId(follow.getFollowing().getId())
+                .senderId(follow.getSender().getId())
+                .receiverId(follow.getReceiver().getId())
                 .createdAt(follow.getCreatedAt())
                 .updatedAt(follow.getUpdatedAt())
                 .build();
     }
 
-    public static Follow toFollow(FollowRequestDTO.CreateFollowDTO request, User follwer, User following) {
+    public static Follow toFollow(FollowRequestDTO.CreateFollowDTO request, User sender, User receiver) {
         return Follow.builder()
-                .follower(follwer)
-                .following(following)
+                .sender(sender)
+                .receiver(receiver)
                 .build();
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowRequestDTO.java
@@ -1,6 +1,5 @@
 package UMC_7th.Closit.domain.follow.dto;
 
-import UMC_7th.Closit.global.validation.annotation.ExistUser;
 import UMC_7th.Closit.global.validation.annotation.ExistUserClositId;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -10,8 +9,8 @@ public class FollowRequestDTO {
     @Getter
     public static class CreateFollowDTO {
 
-        @NotNull(message = "팔로워 id는 필수 입력 값입니다.")
+        @NotNull(message = "팔로우를 받는 사용자의 id는 필수 입력 값입니다.")
         @ExistUserClositId
-        private String follower;
+        private String receiver;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/dto/FollowResponseDTO.java
@@ -15,8 +15,8 @@ public class FollowResponseDTO {
     @AllArgsConstructor
     public static class CreateFollowResultDTO {
         private Long followId;
-        private Long followerId;
-        private Long followingId;
+        private Long senderId;
+        private Long receiverId;
         private LocalDateTime createdAt;
     }
 
@@ -26,8 +26,8 @@ public class FollowResponseDTO {
     @AllArgsConstructor
     public static class FollowDTO {
         private Long followId;
-        private Long followerId;
-        private Long followingId;
+        private Long senderId;
+        private Long receiverId;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }

--- a/src/main/java/UMC_7th/Closit/domain/follow/entity/Follow.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/entity/Follow.java
@@ -11,7 +11,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "follow", uniqueConstraints = {
-        @UniqueConstraint(name = "UK_follower_following", columnNames = {"follower_id", "following_id"})
+        @UniqueConstraint(name = "UK_sender_receiver", columnNames = {"sender_id", "receiver_id"})
 })
 public class Follow extends BaseEntity {
 
@@ -21,10 +21,10 @@ public class Follow extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "follower_id", nullable = false)
-    private User follower;
+    @JoinColumn(name = "sender_id", nullable = false)
+    private User sender;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "following_id", nullable = false)
-    private User following;
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
 }

--- a/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
@@ -16,12 +16,12 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     boolean existsByFollowerAndFollowing(User follower, User following);
 
-    // followerId와 followingId로 특정 팔로우 관계 조회
-    Optional<Follow> findByFollowerClositIdAndFollowingClositId(String followerClositId, String followingClositId);
+    // senderId와 receiverId로 특정 팔로우 관계 조회
+    Optional<Follow> findBySenderClositIdAndReceiverClositId(String senderClositId, String receiverClositId);
 
     // 특정 유저를 팔로우하는 사람 목록 조회 (팔로워)
-    Slice<Follow> findByFollower(User user, Pageable pageable);
+    Slice<Follow> findByReceiver(User user, Pageable pageable);
 
     // 특정 유저가 팔로우하는 사람 목록 조회 (팔로잉)
-    Slice<Follow> findByFollowing(User user, Pageable pageable);
+    Slice<Follow> findBySender(User user, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/repository/FollowRepository.java
@@ -12,9 +12,9 @@ import java.util.Optional;
 
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
-    List<Follow> findByFollowing(User follower);
+    List<Follow> findBySender(User sender);
 
-    boolean existsByFollowerAndFollowing(User follower, User following);
+    boolean existsBySenderAndReceiver(User sender, User receiver);
 
     // senderId와 receiverId로 특정 팔로우 관계 조회
     Optional<Follow> findBySenderClositIdAndReceiverClositId(String senderClositId, String receiverClositId);

--- a/src/main/java/UMC_7th/Closit/domain/follow/service/FollowCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/service/FollowCommandService.java
@@ -7,7 +7,7 @@ public interface FollowCommandService {
 
     Follow createFollow(FollowRequestDTO.CreateFollowDTO request);
 
-    boolean isFollowing(String followerClositId);
+    boolean isFollowing(String receiverClositId);
 
-    void deleteFollow(String followerClositId, String followingClositId);
+    void deleteFollow(String receiverClositId);
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -123,8 +123,8 @@ public class NotiCommandServiceImpl implements NotiCommandService {
 
     @Override
     public void followNotification(Follow follow) { // 팔로우 알림
-        User receiver = follow.getFollower(); // 팔로워 알림 받는 사용자
-        String content = follow.getFollowing().getName() + "님이 회원님을 팔로우하기 시작했습니다. ";
+        User receiver = follow.getReceiver(); // 팔로워 알림 받는 사용자
+        String content = follow.getReceiver().getName() + "님이 회원님을 팔로우하기 시작했습니다. ";
 
         NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, NotificationType.FOLLOW);
 

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/LikeController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/LikeController.java
@@ -1,6 +1,5 @@
 package UMC_7th.Closit.domain.post.controller;
 
-import UMC_7th.Closit.domain.post.converter.LikeConverter;
 import UMC_7th.Closit.domain.post.dto.LikeRequestDTO;
 import UMC_7th.Closit.domain.post.dto.LikeResponseDTO;
 import UMC_7th.Closit.domain.post.service.LikeService;

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
@@ -46,15 +46,29 @@ public class PostController {
         return ApiResponse.onSuccess(postPreviewDTO);
     }
 
-    @Operation(summary = "게시글 목록 조회")
+    @Operation(summary = "팔로우 기반 게시글 조회")
     @GetMapping
-    public ApiResponse<PostResponseDTO.PostPreviewListDTO> getPostList(
-            PostRequestDTO.GetPostDTO request,
+    public ApiResponse<PostResponseDTO.PostPreviewListDTO> getPostListByFollowing(
+            @RequestParam(name = "follower", defaultValue = "false") boolean follower,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
         Pageable pageable = PageRequest.of(page, size);
-        Slice<Post> posts = postQueryService.getPostListByFollowerAndHashtag(request, pageable);
+        Slice<Post> posts = postQueryService.getPostListByFollowing(follower, pageable);
+        PostResponseDTO.PostPreviewListDTO response = PostConverter.toPostPreviewListDTO(posts);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "해시태그 기반 게시글 검색")
+    @GetMapping("/hashtag")
+    public ApiResponse<PostResponseDTO.PostPreviewListDTO> getPostListByHashtag(
+            @RequestParam(name = "hashtag", required = false) String hashtag,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<Post> posts = postQueryService.getPostListByHashtag(hashtag, pageable);
         PostResponseDTO.PostPreviewListDTO response = PostConverter.toPostPreviewListDTO(posts);
 
         return ApiResponse.onSuccess(response);

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/LikeConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/LikeConverter.java
@@ -1,6 +1,5 @@
 package UMC_7th.Closit.domain.post.converter;
 
-import UMC_7th.Closit.domain.post.dto.LikeRequestDTO;
 import UMC_7th.Closit.domain.post.dto.LikeResponseDTO;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.user.entity.User;

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/PostConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/PostConverter.java
@@ -32,7 +32,7 @@ public class PostConverter {
 
         return PostResponseDTO.PostPreviewDTO.builder()
                 .postId(post.getId())
-                .userId(post.getUser().getId())
+                .clositId(post.getUser().getClositId())
                 .profileImage(post.getUser().getProfileImage())
                 .frontImage(post.getFrontImage())
                 .backImage(post.getBackImage())

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/LikeRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/LikeRequestDTO.java
@@ -1,7 +1,6 @@
 package UMC_7th.Closit.domain.post.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/PostRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/PostRequestDTO.java
@@ -11,14 +11,6 @@ import java.util.List;
 public class PostRequestDTO {
 
     @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class GetPostDTO {
-        private boolean follower;
-        private String hashtag;
-    }
-
-    @Getter
     @Builder
     public static class CreatePostDTO{
         private String frontImage;
@@ -36,7 +28,6 @@ public class PostRequestDTO {
     @AllArgsConstructor
     @Builder
     public static class UpdatePostDTO {
-        private String clositId;
         private String frontImage;
         private String backImage;
         private List<String> hashtags;

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/PostResponseDTO.java
@@ -17,7 +17,7 @@ public class PostResponseDTO {
     @AllArgsConstructor
     public static class PostPreviewDTO { // 게시글 목록 조회
         private Long postId;
-        private Long userId;
+        private String clositId;
         private String profileImage;
         private String frontImage;
         private String backImage;

--- a/src/main/java/UMC_7th/Closit/domain/post/service/PostQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/PostQueryService.java
@@ -2,12 +2,15 @@ package UMC_7th.Closit.domain.post.service;
 
 import UMC_7th.Closit.domain.post.dto.PostRequestDTO;
 import UMC_7th.Closit.domain.post.entity.Post;
-import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface PostQueryService {
 
-    Slice<Post> getPostListByFollowerAndHashtag(PostRequestDTO.GetPostDTO request, Pageable pageable);
+    // 팔로우 기반 게시글 조회
+    Slice<Post> getPostListByFollowing(boolean follower, Pageable pageable);
+    
+    // 해시태그 기반 게시글 검색
+    Slice<Post> getPostListByHashtag(String hashtag, Pageable pageable);
 }
 

--- a/src/main/java/UMC_7th/Closit/domain/post/service/PostService.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/PostService.java
@@ -38,8 +38,8 @@ public class PostService {
         Boolean isSaved = bookmarkRepository.existsByUserAndPost(currentUser, post);
 
         // 친구 여부 확인
-        Boolean isFriend = followRepository.existsByFollowerAndFollowing(currentUser, post.getUser()) &&
-                followRepository.existsByFollowerAndFollowing(post.getUser(), currentUser);
+        Boolean isFriend = followRepository.existsBySenderAndReceiver(currentUser, post.getUser()) &&
+                followRepository.existsBySenderAndReceiver(post.getUser(), currentUser);
 
         // 해시태그 조회
         List<String> hashtags = postHashTagRepository.findByPost(post).stream()

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -103,7 +103,7 @@ public class UserController {
 
     @Operation(summary = "closit id 중복 여부 조회", description = "특정 closit id가 이미 있는 id인지 조회합니다.")
     @GetMapping("/isunique/{closit_id}")
-    public ApiResponse<Boolean> getUserMissions(@PathVariable String closit_id) {
+    public ApiResponse<Boolean> isUniqueClositId(@PathVariable String closit_id) {
         return ApiResponse.onSuccess(userCommandService.isClositIdUnique(closit_id));
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -88,11 +88,11 @@ public class User extends BaseEntity {
     @Builder.Default
     private List<BattleLike> battleLikesList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Follow> followerList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Follow> followingList = new ArrayList<>();
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -18,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -44,8 +43,8 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findByClositId(clositId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Slice<Follow> followers = followRepository.findByFollower(user, pageable);
-        return followers.map(Follow::getFollowing);
+        Slice<Follow> followers = followRepository.findByReceiver(user, pageable);
+        return followers.map(Follow::getSender);
     }
 
     @Override
@@ -53,8 +52,8 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findByClositId(clositId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        Slice<Follow> followings = followRepository.findByFollowing(user, pageable);
-        return followings.map(Follow::getFollower);
+        Slice<Follow> followings = followRepository.findBySender(user, pageable);
+        return followings.map(Follow::getReceiver);
     }
 
     @Override


### PR DESCRIPTION
## #️⃣연관된 이슈

> #95 [#45 fix: 팔로우 관련 API 수정]

## 📝작업 내용

- 팔로우 삭제 api의 파라미터 수정
- 팔로우 여부 조회 api의 uri 수정
- follower, following -> sender, receiver 필드명 수정
- 게시글 목록 조회, 해시태그 검색 api 분리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

