### PR TITLE
#111 fix: 배틀 좋아요 삭제 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleLikeController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleLikeController.java
@@ -59,17 +59,15 @@ public class BattleLikeController {
             description = """
             ## 배틀 게시글 내 특정 좋아요 취소
             ### PathVariable
-            battle_id [배틀 ID] \n
-            battle_like_id [배틀 좋아요 ID]
+            battle_id [배틀 ID]
             """)
-    @DeleteMapping("{battle_id}/likes/{battle_like_id}")
-    public ApiResponse<String> deleteBattleLike(@PathVariable("battle_id") Long battleId,
-                                                @PathVariable("battle_like_id") Long battleLikeId) {
+    @DeleteMapping("{battle_id}/likes")
+    public ApiResponse<String> deleteBattleLike(@PathVariable("battle_id") Long battleId) {
 
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 
-        battleLikeCommandService.deleteBattleLike(userId, battleId, battleLikeId);
+        battleLikeCommandService.deleteBattleLike(userId, battleId);
 
         return ApiResponse.onSuccess("Deletion successful");
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleLikeRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleLikeRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BattleLikeRepository extends JpaRepository<BattleLike, Long> {
+import java.util.Optional;
 
+public interface BattleLikeRepository extends JpaRepository<BattleLike, Long> {
    boolean existsBattleLikeByBattleIdAndUserId(Long battleId, Long userId); // 배틀 좋아요 생성
    Slice<BattleLike> findAllByBattleId(Long battleId, Pageable pageable);
+   Optional<BattleLike> findByUserIdAndBattleId(Long userId, Long battleId); // 배틀 좋아요 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleLikeService/BattleLikeCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleLikeService/BattleLikeCommandService.java
@@ -4,5 +4,5 @@ import UMC_7th.Closit.domain.battle.entity.BattleLike;
 
 public interface BattleLikeCommandService {
     BattleLike createBattleLike(Long userId, Long battleId); // 배틀 좋아요 생성
-    void deleteBattleLike(Long userId, Long battleId, Long battleLikeId); // 배틀 좋아요 삭제
+    void deleteBattleLike(Long userId, Long battleId); // 배틀 좋아요 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleLikeService/BattleLikeCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleLikeService/BattleLikeCommandServiceImpl.java
@@ -43,12 +43,12 @@ public class BattleLikeCommandServiceImpl implements BattleLikeCommandService {
     }
 
     @Override
-    public void deleteBattleLike (Long userId, Long battleId, Long battleLikeId) {
+    public void deleteBattleLike (Long userId, Long battleId) { // 배틀 좋아요 삭제
         Battle battle = battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 
-        BattleLike battleLike = battleLikeRepository.findById(battleLikeId)
-                        .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_LIKES_NOT_FOUND));
+        BattleLike battleLike = battleLikeRepository.findByUserIdAndBattleId(userId, battleId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_LIKES_NOT_FOUND));
 
         battle.decreaseLikeCount();
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #111 fix: 배틀 좋아요 삭제 API 수정

## 📝작업 내용

> battleId만 받게 수정

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3338aa69-9b40-4d3c-aefc-0f5fe349c3d5)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
