### PR TITLE
#118 refactor: 사용자의 최근 게시물 조회 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -61,6 +61,7 @@ public class UserConverter {
                 .clositId(post.getUser().getClositId())
                 .userName(post.getUser().getName())
                 .postId(post.getId())
+                .thumbnail(post.getFrontImage())
                 .createdAt(post.getCreatedAt())
                 .build();
     }

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
@@ -111,6 +111,7 @@ public class UserResponseDTO {
         private String clositId;
         private String userName;
         private Long postId;
+        private String thumbnail;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #118 refactor: 사용자의 최근 게시물 조회 API 수정

## 📝작업 내용

> 사용자 최근 게시물 조회 시 썸네일 추가 (frontImage) 

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a965bb27-3ad4-40e0-98ae-7291ec42d503)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요