### PR TITLE
#127 fix: 알림 관련 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/repository/NotificationRepository.java
@@ -5,7 +5,17 @@ import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
-    Slice<Notification> findByUserOrderByCreatedAtDesc(User user, Pageable pageable); // 알림 목록 조회
+    Slice<Notification> findByUserAndIsReadFalseOrderByCreatedAtDesc(User user, Pageable pageable); // 알림 목록 조회 - isRead = false
+    Slice<Notification> findByUserAndIsReadTrueOrderByUpdatedAtDesc(User user, Pageable pageable); // 알림 목록 조회 - isRead = true
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.isRead = true, n.updatedAt = :updatedAt WHERE n.user.id = :userId AND n.isRead = false")
+    Integer updateReadStatusByUserId (@Param("userId") Long userId, @Param("updatedAt") LocalDateTime updatedAt); // isRead 업데이트
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -108,27 +108,31 @@ public class NotiCommandServiceImpl implements NotiCommandService {
     @Override
     public void likeNotification(Likes likes) { // 좋아요 알림
         User receiver = likes.getPost().getUser(); // 게시글 작성자
-        String content = likes.getUser().getName() + "님이 좋아요를 눌렀습니다. ";
+        String content = likes.getUser().getName() + "님이 좋아요를 눌렀습니다.";
 
-        NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, NotificationType.LIKE);
-
-        sendNotification(request);
+        // 좋아요를 누른 사용자가 본인이 아닐 경우, 알림 전송
+        if (!receiver.getId().equals(likes.getUser().getId())) {
+            NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, NotificationType.LIKE);
+            sendNotification(request);
+        }
     }
 
     @Override
     public void commentNotification(Comment comment) { // 댓글 알림
         User receiver = comment.getPost().getUser(); // 게시글 작성자 ID
-        String content = comment.getUser().getName() + "님이 댓글을 작성했습니다. ";
+        String content = comment.getUser().getName() + "님이 댓글을 작성했습니다.";
 
-        NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, NotificationType.COMMENT);
-
-        sendNotification(request);
+        // 댓글을 작성한 사용자가 본인이 아닐 경우, 알림 전송
+        if (!receiver.getId().equals(comment.getUser().getId())) {
+            NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, NotificationType.COMMENT);
+            sendNotification(request);
+        }
     }
 
     @Override
     public void followNotification(Follow follow) { // 팔로우 알림
         User receiver = follow.getReceiver(); // 팔로워 알림 받는 사용자
-        String content = follow.getReceiver().getName() + "님이 회원님을 팔로우하기 시작했습니다. ";
+        String content = follow.getReceiver().getName() + "님이 회원님을 팔로우하기 시작했습니다.";
 
         NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, NotificationType.FOLLOW);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #127 fix: 알림 관련 API 수정

## 📝작업 내용

> 좋아요, 댓글 작성자가 본인일 경우 알림 전송 X
처음 알림 조회 시 isRead = false, 두 번째 조회부터 isRead = true

## 스크린샷 (선택)
> 좋아요, 댓글 작성자가 본인일 경우 알림 전송 X
![스크린샷 2025-02-18 012614](https://github.com/user-attachments/assets/3e02ff6c-ec82-4901-9960-92e98e1efb27)

> 처음 알림 조회 시 isRead = false, 두 번째 조회부터 isRead = true
![스크린샷 2025-02-18 012049](https://github.com/user-attachments/assets/5d0c6ce0-e1c0-46ac-a3d9-edc3af3ccbd3)
![스크린샷 2025-02-18 012102](https://github.com/user-attachments/assets/82f7c737-fe44-40d6-b12f-8ef380105e68)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

