### PR TITLE
#143 fix: 사용자 중복 확인 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -1,9 +1,7 @@
 package UMC_7th.Closit.security;
 
-import UMC_7th.Closit.domain.user.service.CustomUserDetailService;
 import UMC_7th.Closit.security.jwt.JwtAccessDeniedHandler;
 import UMC_7th.Closit.security.jwt.JwtAuthenticationEntryPoint;
-import UMC_7th.Closit.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
                         .requestMatchers("/","/swagger-ui/**","/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/auth/register",
                                          "/api/auth/login",
-                                         "/api/auth/refresh").permitAll()
+                                         "/api/auth/refresh",
+                                         "/api/auth/users/isunique/**").permitAll()
                         .anyRequest().authenticated())
                 // UsernamePasswordAuthenticationFilter 전에 JwtAuthenticationFilter 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #143 fix: 사용자 중복 확인 API 수정

## 📝작업 내용

> 사용자 중복 확인 시, 401 에러 수정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/adabd825-db10-4677-af53-458320eee080)
![image](https://github.com/user-attachments/assets/29f9b2c7-59d0-4d61-b518-1f0a1319d1b1)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
