### PR TITLE
#142 feat: 메일 인증 코드 전송 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+	// SMTP
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/UMC_7th/Closit/domain/mail/controller/MailController.java
+++ b/src/main/java/UMC_7th/Closit/domain/mail/controller/MailController.java
@@ -1,0 +1,26 @@
+package UMC_7th.Closit.domain.mail.controller;
+
+import UMC_7th.Closit.domain.mail.service.MailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/auth/mail")
+public class MailController {
+    private final MailService mailService;
+
+    @ResponseBody
+    @PostMapping
+    public String MailSend(String mail){
+
+        int number = mailService.sendMail(mail);
+
+        String num = "" + number;
+
+        return num;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/mail/service/MailService.java
+++ b/src/main/java/UMC_7th/Closit/domain/mail/service/MailService.java
@@ -1,0 +1,47 @@
+package UMC_7th.Closit.domain.mail.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+    private final JavaMailSender javaMailSender;
+    private static final String senderEmail= "clositback@gmail.com";
+    private static int number;
+
+    // 랜덤으로 숫자 생성
+    public static void createNumber() {
+        number = (int)(Math.random() * (90000)) + 100000;
+    }
+
+    public MimeMessage CreateMail(String mail) {
+        createNumber();
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            message.setFrom(senderEmail);
+            message.setRecipients(MimeMessage.RecipientType.TO, mail);
+            message.setSubject("이메일 인증");
+            String body = "";
+            body += "<h3>" + "요청하신 인증 번호입니다." + "</h3>";
+            body += "<h1>" + number + "</h1>";
+            body += "<h3>" + "감사합니다." + "</h3>";
+            message.setText(body,"UTF-8", "html");
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+
+        return message;
+    }
+
+    public int sendMail(String mail) {
+        MimeMessage message = CreateMail(mail);
+        javaMailSender.send(message);
+
+        return number;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -50,7 +50,9 @@ public class SecurityConfig {
                         .requestMatchers("/","/swagger-ui/**","/v3/api-docs/**").permitAll()
                         .requestMatchers("/api/auth/register",
                                          "/api/auth/login",
-                                         "/api/auth/refresh").permitAll()
+                                         "/api/auth/refresh",
+                                         "/api/auth/users/isunique/**",
+                                         "/api/auth/mail").permitAll()
                         .anyRequest().authenticated())
                 // UsernamePasswordAuthenticationFilter 전에 JwtAuthenticationFilter 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #142 

## 📝작업 내용

> 사용자가 입력한 메일로 인증 코드를 전송하여 유효한 메일인지 검증하는 api를 구현하였습니다. 

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/b36738ce-ce76-4c36-b662-33b396b2b6b7)
![image](https://github.com/user-attachments/assets/f13e0084-4436-4cd3-8290-8bdf1a0af975)
![image](https://github.com/user-attachments/assets/ee6235c0-07c8-499c-a767-2c0b85989e04)

## 💬리뷰 요구사항(선택)

