### PR TITLE
#149 fix: 배틀 댓글 삭제 API 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleCmtService/BattleCmtCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleCmtService/BattleCmtCommandServiceImpl.java
@@ -39,7 +39,7 @@ public class BattleCmtCommandServiceImpl implements BattleCmtCommandService {
     @Override
     @Transactional
     public void deleteBattleComment(Long userId, Long battleId, Long battleCommentId) { // 배틀 댓글 삭제
-        Battle battle = battleRepository.findById(userId)
+        battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 
         BattleComment battleComment = battleCommentRepository.findById(battleCommentId)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #149 fix: 배틀 댓글 삭제 API 수정

## 📝작업 내용

>  배틀 댓글 삭제 API 수정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/11dd2b98-86ef-4f4e-8c3e-13221cd91d0b)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
