### PR TITLE
#161 fix: battle comment 생성 api response에 clositId 추가

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
@@ -22,6 +22,7 @@ public class BattleCommentConverter {
 
     public static BattleCommentResponseDTO.createBattleCommentResultDTO createBattleCommentResponseDTO (BattleComment battleComment) {
         return BattleCommentResponseDTO.createBattleCommentResultDTO.builder()
+                .clositId(battleComment.getUser().getClositId())
                 .battleCommentId(battleComment.getId())
                 .createdAt(battleComment.getCreatedAt())
                 .build();

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
@@ -17,6 +17,7 @@ public class BattleCommentResponseDTO {
     @AllArgsConstructor
     public static class createBattleCommentResultDTO { // 배틀 댓글 생성
         private Long battleCommentId;
+        private String clositId;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #161 

## 📝작업 내용

> battle comment 생성 api에서 response값에 clositId를 추가했습니다.
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
