### PR TITLE
#170 fix: 배틀 게시글 목록 이미지 반환

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
@@ -22,8 +22,9 @@ public class BattleCommentConverter {
 
     public static BattleCommentResponseDTO.createBattleCommentResultDTO createBattleCommentResponseDTO (BattleComment battleComment) {
         return BattleCommentResponseDTO.createBattleCommentResultDTO.builder()
-                .clositId(battleComment.getUser().getClositId())
                 .battleCommentId(battleComment.getId())
+                .clositId(battleComment.getUser().getClositId())
+                .thumbnail(battleComment.getUser().getProfileImage())
                 .createdAt(battleComment.getCreatedAt())
                 .build();
     }
@@ -32,6 +33,7 @@ public class BattleCommentConverter {
         return BattleCommentResponseDTO.BattleCommentPreviewDTO.builder()
                 .battleCommentId(battleComment.getId())
                 .clositId(battleComment.getUser().getClositId())
+                .thumbnail(battleComment.getUser().getProfileImage())
                 .content(battleComment.getContent())
                 .createdAt(battleComment.getCreatedAt())
                 .build();

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -22,6 +22,7 @@ public class BattleConverter {
     public static BattleResponseDTO.CreateBattleResultDTO createBattleResultDTO(Battle battle) {
         return BattleResponseDTO.CreateBattleResultDTO.builder()
                 .battleId(battle.getId())
+                .thumbnail(battle.getPost1().getUser().getProfileImage())
                 .deadline(battle.getDeadline())
                 .createdAt(battle.getCreatedAt())
                 .build();
@@ -31,6 +32,8 @@ public class BattleConverter {
         return BattleResponseDTO.ChallengeBattleResultDTO.builder()
                 .firstClositId(battle.getPost1().getUser().getClositId())
                 .firstPostId(battle.getPost1().getId())
+                .firstPostFrontImage(battle.getPost1().getFrontImage())
+                .firstPostBackImage(battle.getPost1().getBackImage())
                 .secondClositId(battle.getPost2().getUser().getClositId())
                 .secondPostId(battle.getPost2().getId())
                 .createdAt(battle.getCreatedAt())
@@ -61,12 +64,16 @@ public class BattleConverter {
                 .isLiked(!battle.getBattleLikesList().isEmpty())
                 .title(battle.getTitle())
                 .firstClositId(battle.getPost1().getUser().getClositId())
-                .firstPostId(battle.getPost1().getId())
                 .firstProfileImage(battle.getPost1().getUser().getProfileImage())
+                .firstPostId(battle.getPost1().getId())
+                .firstPostFrontImage(battle.getPost1().getFrontImage())
+                .firstPostBackImage(battle.getPost1().getBackImage())
                 .firstVotingRate(battle.getFirstVotingRate())
                 .secondClositId(battle.getPost2().getUser().getClositId())
-                .secondPostId(battle.getPost2().getId())
                 .secondProfileImage(battle.getPost2().getUser().getProfileImage())
+                .secondPostId(battle.getPost2().getId())
+                .secondPostBackImage(battle.getPost2().getFrontImage())
+                .secondPostBackImage(battle.getPost2().getBackImage())
                 .secondVotingRate(battle.getSecondVotingRate())
                 .build();
     }
@@ -89,6 +96,8 @@ public class BattleConverter {
                 .battleId(battle.getId())
                 .firstClositId(battle.getPost1().getUser().getClositId())
                 .firstPostId(battle.getPost1().getId())
+                .firstPostFrontImage(battle.getPost1().getFrontImage())
+                .firstPostBackImage(battle.getPost1().getBackImage())
                 .title(battle.getTitle())
                 .build();
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -22,7 +22,7 @@ public class BattleConverter {
     public static BattleResponseDTO.CreateBattleResultDTO createBattleResultDTO(Battle battle) {
         return BattleResponseDTO.CreateBattleResultDTO.builder()
                 .battleId(battle.getId())
-                .thumbnail(battle.getPost1().getUser().getProfileImage())
+                .thumbnail(battle.getPost1().getFrontImage())
                 .deadline(battle.getDeadline())
                 .createdAt(battle.getCreatedAt())
                 .build();
@@ -36,6 +36,8 @@ public class BattleConverter {
                 .firstPostBackImage(battle.getPost1().getBackImage())
                 .secondClositId(battle.getPost2().getUser().getClositId())
                 .secondPostId(battle.getPost2().getId())
+                .secondPostFrontImage(battle.getPost2().getFrontImage())
+                .secondPostBackImage(battle.getPost2().getBackImage())
                 .createdAt(battle.getCreatedAt())
                 .build();
     }
@@ -72,7 +74,7 @@ public class BattleConverter {
                 .secondClositId(battle.getPost2().getUser().getClositId())
                 .secondProfileImage(battle.getPost2().getUser().getProfileImage())
                 .secondPostId(battle.getPost2().getId())
-                .secondPostBackImage(battle.getPost2().getFrontImage())
+                .secondPostFrontImage(battle.getPost2().getFrontImage())
                 .secondPostBackImage(battle.getPost2().getBackImage())
                 .secondVotingRate(battle.getSecondVotingRate())
                 .build();
@@ -95,6 +97,7 @@ public class BattleConverter {
         return BattleResponseDTO.ChallengeBattlePreviewDTO.builder()
                 .battleId(battle.getId())
                 .firstClositId(battle.getPost1().getUser().getClositId())
+                .firstProfileImage(battle.getPost1().getUser().getProfileImage())
                 .firstPostId(battle.getPost1().getId())
                 .firstPostFrontImage(battle.getPost1().getFrontImage())
                 .firstPostBackImage(battle.getPost1().getBackImage())

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleLikeConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleLikeConverter.java
@@ -22,6 +22,7 @@ public class BattleLikeConverter {
     public static BattleLikeResponseDTO.CreateBattleLikeResultDTO createBattleLikeResultDTO(BattleLike battleLike) {
         return BattleLikeResponseDTO.CreateBattleLikeResultDTO.builder()
                 .battleLikeId(battleLike.getId())
+                .clositId(battleLike.getUser().getClositId())
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
@@ -18,6 +18,7 @@ public class BattleCommentResponseDTO {
     public static class createBattleCommentResultDTO { // 배틀 댓글 생성
         private Long battleCommentId;
         private String clositId;
+        private String thumbnail;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
@@ -29,6 +30,7 @@ public class BattleCommentResponseDTO {
     public static class BattleCommentPreviewDTO { // 배틀 댓글 조회
         private Long battleCommentId;
         private String clositId;
+        private String thumbnail;
         private String content;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -18,6 +18,7 @@ public class BattleResponseDTO {
     @AllArgsConstructor
     public static class CreateBattleResultDTO { // 배틀 생성
         private Long battleId;
+        private String thumbnail;
         @JsonFormat(pattern = "yyyy/MM/dd")
         private LocalDate deadline;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
@@ -31,8 +32,12 @@ public class BattleResponseDTO {
     public static class ChallengeBattleResultDTO { // 배틀 신청
         private String firstClositId;
         private Long firstPostId;
+        private String firstPostFrontImage;
+        private String firstPostBackImage;
         private String secondClositId;
         private Long secondPostId;
+        private String secondPostFrontImage;
+        private String secondPostBackImage;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
@@ -60,12 +65,16 @@ public class BattleResponseDTO {
         private boolean isLiked;
         private String title;
         private String firstClositId;
-        private Long firstPostId;
         private String firstProfileImage;
+        private Long firstPostId;
+        private String firstPostFrontImage;
+        private String firstPostBackImage;
         private double firstVotingRate;
         private String secondClositId;
-        private Long secondPostId;
         private String secondProfileImage;
+        private Long secondPostId;
+        private String secondPostFrontImage;
+        private String secondPostBackImage;
         private double secondVotingRate;
     }
 
@@ -88,8 +97,10 @@ public class BattleResponseDTO {
     public static class ChallengeBattlePreviewDTO { // 배틀 챌린지 게시글 목록 조회
         private Long battleId;
         private String firstClositId;
-        private Long firstPostId;
         private String firstProfileImage;
+        private Long firstPostId;
+        private String firstPostFrontImage;
+        private String firstPostBackImage;
         private String title;
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleLikeDTO/BattleLikeResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleLikeDTO/BattleLikeResponseDTO.java
@@ -17,6 +17,7 @@ public class BattleLikeResponseDTO {
     @AllArgsConstructor
     public static class CreateBattleLikeResultDTO { // 배틀 좋아요 생성
         private Long battleLikeId;
+        private String clositId;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #170 fix: 배틀 게시글 목록 이미지 반환

## 📝작업 내용

> 배틀 게시글 목록 이미지 반환

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f01e5217-28e2-48cb-9571-3783e73f5331)
![image](https://github.com/user-attachments/assets/c38d2eea-92d9-4762-9681-9dd726488f9e)
![image](https://github.com/user-attachments/assets/f077abf4-fa05-475e-80ec-f87f1bf8ef7e)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
