### PR TITLE
#183 fix: 사용자 삭제 API

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
@@ -12,9 +12,9 @@ import java.util.stream.Collectors;
 
 public class NotificationConverter {
 
-    public static Notification toNotification (User user, User sender, NotificationRequestDTO.SendNotiRequestDTO request) { // 알림 전송
+    public static Notification toNotification (User receiver, User sender, NotificationRequestDTO.SendNotiRequestDTO request) { // 알림 전송
         return Notification.builder()
-                .user(user)
+                .user(receiver)
                 .sender(sender)
                 .content(request.getContent())
                 .type(request.getType())

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -115,7 +115,7 @@ public class NotiCommandServiceImpl implements NotiCommandService {
         String content = likes.getUser().getName() + "님이 좋아요를 눌렀습니다.";
 
         // 좋아요를 누른 사용자가 본인이 아닐 경우, 알림 전송
-        if (!receiver.getId().equals(likes.getUser().getId())) {
+        if (!receiver.getId().equals(sender.getId())) {
             NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, sender, content, NotificationType.LIKE);
             sendNotification(request);
         }
@@ -128,7 +128,7 @@ public class NotiCommandServiceImpl implements NotiCommandService {
         String content = comment.getUser().getName() + "님이 댓글을 작성했습니다.";
 
         // 댓글을 작성한 사용자가 본인이 아닐 경우, 알림 전송
-        if (!receiver.getId().equals(comment.getUser().getId())) {
+        if (!receiver.getId().equals(sender.getId())) {
             NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, sender, content, NotificationType.COMMENT);
             sendNotification(request);
         }

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/CommentRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/CommentRepository.java
@@ -4,8 +4,14 @@ import UMC_7th.Closit.domain.post.entity.Comment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Slice<Comment> findAllByPostId(Long postId, Pageable pageable);
-}
 
+    @Modifying
+    @Query(value = "DELETE FROM comment WHERE user_id = :userId", nativeQuery = true)
+    void deleteByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/LikeRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/LikeRepository.java
@@ -4,6 +4,9 @@ import UMC_7th.Closit.domain.post.entity.Likes;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -13,4 +16,8 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
     boolean existsByUserAndPost(User user, Post post);
     
     Optional<Likes> findByUserAndPost(User user, Post post);
+
+    @Modifying
+    @Query(value = "DELETE FROM likes WHERE user_id = :userId", nativeQuery = true)
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -60,11 +60,11 @@ public class User extends BaseEntity {
     @Builder.Default
     private List<Post> postList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Comment> commentList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Likes> likesList = new ArrayList<>();
 
@@ -98,7 +98,11 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
-    private List<Notification> notificationList = new ArrayList<>();
+    private List<Notification> notificationUserList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Notification> notificationSenderList = new ArrayList<>();
 
     public User updateRole(Role newRole) {
         this.role = newRole;

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -1,11 +1,10 @@
 package UMC_7th.Closit.domain.user.service;
 
-import UMC_7th.Closit.domain.follow.entity.Follow;
-import UMC_7th.Closit.domain.follow.repository.FollowRepository;
-import UMC_7th.Closit.domain.user.converter.UserConverter;
+import UMC_7th.Closit.domain.notification.repository.NotificationRepository;
+import UMC_7th.Closit.domain.post.repository.CommentRepository;
+import UMC_7th.Closit.domain.post.repository.LikeRepository;
 import UMC_7th.Closit.domain.user.dto.RegisterResponseDTO;
 import UMC_7th.Closit.domain.user.dto.UserRequestDTO;
-import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
 import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
@@ -31,6 +30,8 @@ import java.util.UUID;
 public class UserCommandServiceImpl implements UserCommandService {
 
     private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
     private final PasswordEncoder passwordEncoder;
 
     private final SecurityUtil securityUtil;
@@ -90,6 +91,10 @@ public class UserCommandServiceImpl implements UserCommandService {
         // 🛠 해결: JPA 영속 상태로 변환
         User persistentUser = userRepository.findById(currentUser.getId())
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 댓글, 좋아요 삭제 후 먼저 삭제 후 탈퇴
+        commentRepository.deleteByUserId(persistentUser.getId());
+        likeRepository.deleteByUserId(persistentUser.getId());
 
         userRepository.delete(persistentUser);
     }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -92,7 +92,7 @@ public class UserCommandServiceImpl implements UserCommandService {
         User persistentUser = userRepository.findById(currentUser.getId())
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 댓글, 좋아요 삭제 후 먼저 삭제 후 탈퇴
+        // 댓글, 좋아요 먼저 삭제 후 탈퇴
         commentRepository.deleteByUserId(persistentUser.getId());
         likeRepository.deleteByUserId(persistentUser.getId());
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #183 fix: 사용자 삭제 API

## 📝작업 내용

> 사용자 삭제 API 수정
- 문제 발생 상황: 좋아요, 댓글 생성과 이에 대한 알림 생성 후 사용자 탈퇴가 안됨 (팔로우는 잘됨) 

## 스크린샷 (선택)
> string만 탈퇴 
![image](https://github.com/user-attachments/assets/fe71154c-f4bb-4dfd-9c18-79221dd0a444)
![image](https://github.com/user-attachments/assets/9857951e-b704-4ce8-8a65-de78b3ad1ac3)
zyovn은 남아 있음

## 💬리뷰 요구사항(선택)

> 이따구로 수정하면 탈퇴가 되긴 하는데...... 이걸 배포를 해도 될지는 모르겠어요
근본적인 문제는 해결이 안된 느낌.......... 
한 번 봐주시고 다른 방식으로 해결하는 게 좋을 것 같으면 더 찾아보겠습니다.
그리고 조금이라도 연관된 다른 사용자까지 삭제가 안되는지 로컬에서 한 번만 확인해주시면 감사하겠습니다...................................
