### PR TITLE
refactor: 배틀 신청 로직 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -80,7 +80,26 @@ public class BattleController {
 
         Battle battle = battleCommandService.acceptChallenge(userId, battleId, request);
 
-        return ApiResponse.onSuccess(BattleConverter.acceptChallengeDTO(battle));
+        return ApiResponse.onSuccess(BattleConverter.challengeDecisionDTO(battle));
+    }
+
+    @PatchMapping("/{battleId}/challenge/reject")
+    @Operation(summary = "배틀 신청 거절",
+            description = """
+            ## 배틀 신청 거절
+            ### PathVariable
+            battleId [배틀 ID[
+            ### RequestBody
+            challengeBattleId [챌린지 배틀 ID]
+            """)
+    public ApiResponse<BattleResponseDTO.ChallengeDecisionDTO> rejectChallenge(@RequestBody @Valid BattleRequestDTO.ChallengeDecisionDTO request,
+                                                                               @PathVariable("battleId") Long battleId) {
+        User user = securityUtil.getCurrentUser();
+        Long userId = user.getId();
+
+        Battle battle = battleCommandService.rejectChallenge(userId, battleId, request);
+
+        return ApiResponse.onSuccess(BattleConverter.challengeDecisionDTO(battle));
     }
 
     @PostMapping("/{battle_id}/voting")

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -73,8 +73,8 @@ public class BattleController {
             ### RequestBody
             challengeBattleId [챌린지 배틀 ID]
             """)
-    public ApiResponse<BattleResponseDTO.AcceptChallengeDTO> acceptChallenge(@RequestBody @Valid BattleRequestDTO.AcceptChallengeDTO request,
-                                                                             @PathVariable("battleId") Long battleId) {
+    public ApiResponse<BattleResponseDTO.ChallengeDecisionDTO> acceptChallenge(@RequestBody @Valid BattleRequestDTO.ChallengeDecisionDTO request,
+                                                                               @PathVariable("battleId") Long battleId) {
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -64,6 +64,25 @@ public class BattleController {
         return ApiResponse.onSuccess(BattleConverter.challengeBattleResultDTO(challengeBattle));
     }
 
+    @PatchMapping("/{battleId}/challenge/accept")
+    @Operation(summary = "배틀 신청 수락",
+            description = """
+            ## 배틀 신청 수락
+            ### PathVariable
+            battleId [배틀 ID]
+            ### RequestBody
+            challengeBattleId [챌린지 배틀 ID]
+            """)
+    public ApiResponse<BattleResponseDTO.AcceptChallengeDTO> acceptChallenge(@RequestBody @Valid BattleRequestDTO.AcceptChallengeDTO request,
+                                                                             @PathVariable("battleId") Long battleId) {
+        User user = securityUtil.getCurrentUser();
+        Long userId = user.getId();
+
+        Battle battle = battleCommandService.acceptChallenge(userId, battleId, request);
+
+        return ApiResponse.onSuccess(BattleConverter.acceptChallengeDTO(battle));
+    }
+
     @PostMapping("/{battle_id}/voting")
     @Operation(summary = "배틀 투표",
             description = """

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -4,6 +4,7 @@ import UMC_7th.Closit.domain.battle.converter.BattleConverter;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleRequestDTO;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleResponseDTO;
 import UMC_7th.Closit.domain.battle.entity.Battle;
+import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
 import UMC_7th.Closit.domain.battle.entity.Vote;
 import UMC_7th.Closit.domain.battle.service.BattleService.BattleCommandService;
 import UMC_7th.Closit.domain.battle.service.BattleService.BattleQueryService;
@@ -58,7 +59,7 @@ public class BattleController {
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 
-        Battle challengeBattle = battleCommandService.challengeBattle(userId, battleId, request);
+        ChallengeBattle challengeBattle = battleCommandService.challengeBattle(userId, battleId, request);
 
         return ApiResponse.onSuccess(BattleConverter.challengeBattleResultDTO(challengeBattle));
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -3,6 +3,8 @@ package UMC_7th.Closit.domain.battle.converter;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleRequestDTO;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleResponseDTO;
 import UMC_7th.Closit.domain.battle.entity.Battle;
+import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
+import UMC_7th.Closit.domain.battle.entity.Status;
 import UMC_7th.Closit.domain.battle.entity.Vote;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.user.entity.User;
@@ -13,32 +15,44 @@ import java.util.stream.Collectors;
 
 public class BattleConverter {
 
-    public static Battle toBattle (Post post, BattleRequestDTO.CreateBattleDTO request) { // 배틀 생성
+    public static Battle toBattle(Post post, BattleRequestDTO.CreateBattleDTO request) { // 배틀 생성
         return Battle.builder()
                 .post1(post)
                 .title(request.getTitle())
+                .status(Status.INACTIVE)
                 .build();
     }
+
     public static BattleResponseDTO.CreateBattleResultDTO createBattleResultDTO(Battle battle) {
         return BattleResponseDTO.CreateBattleResultDTO.builder()
                 .battleId(battle.getId())
                 .thumbnail(battle.getPost1().getFrontImage())
+                .status(battle.getStatus())
                 .deadline(battle.getDeadline())
                 .createdAt(battle.getCreatedAt())
                 .build();
     }
 
-    public static BattleResponseDTO.ChallengeBattleResultDTO challengeBattleResultDTO(Battle battle) {
+    public static ChallengeBattle toChallengeBattle(Battle battle, Post post) { // 배틀 신청
+        return ChallengeBattle.builder()
+                .battle(battle)
+                .post(post)
+                .status(Status.PENDING)
+                .build();
+    }
+
+    public static BattleResponseDTO.ChallengeBattleResultDTO challengeBattleResultDTO(ChallengeBattle challengeBattle) {
         return BattleResponseDTO.ChallengeBattleResultDTO.builder()
-                .firstClositId(battle.getPost1().getUser().getClositId())
-                .firstPostId(battle.getPost1().getId())
-                .firstPostFrontImage(battle.getPost1().getFrontImage())
-                .firstPostBackImage(battle.getPost1().getBackImage())
-                .secondClositId(battle.getPost2().getUser().getClositId())
-                .secondPostId(battle.getPost2().getId())
-                .secondPostFrontImage(battle.getPost2().getFrontImage())
-                .secondPostBackImage(battle.getPost2().getBackImage())
-                .createdAt(battle.getCreatedAt())
+                .firstClositId(challengeBattle.getBattle().getPost1().getUser().getClositId())
+                .firstPostId(challengeBattle.getBattle().getPost1().getId())
+                .firstPostFrontImage(challengeBattle.getBattle().getPost1().getFrontImage())
+                .firstPostBackImage(challengeBattle.getBattle().getPost1().getBackImage())
+                .secondClositId(challengeBattle.getPost().getUser().getClositId())
+                .secondPostId(challengeBattle.getPost().getId())
+                .secondPostFrontImage(challengeBattle.getPost().getFrontImage())
+                .secondPostBackImage(challengeBattle.getPost().getBackImage())
+                .status(challengeBattle.getStatus())
+                .createdAt(challengeBattle.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -43,6 +43,7 @@ public class BattleConverter {
 
     public static BattleResponseDTO.ChallengeBattleResultDTO challengeBattleResultDTO(ChallengeBattle challengeBattle) {
         return BattleResponseDTO.ChallengeBattleResultDTO.builder()
+                .challengeBattleId(challengeBattle.getId())
                 .firstClositId(challengeBattle.getBattle().getPost1().getUser().getClositId())
                 .firstPostId(challengeBattle.getBattle().getPost1().getId())
                 .firstPostFrontImage(challengeBattle.getBattle().getPost1().getFrontImage())
@@ -53,6 +54,21 @@ public class BattleConverter {
                 .secondPostBackImage(challengeBattle.getPost().getBackImage())
                 .status(challengeBattle.getStatus())
                 .createdAt(challengeBattle.getCreatedAt())
+                .build();
+    }
+
+    public static BattleResponseDTO.AcceptChallengeDTO acceptChallengeDTO(Battle battle) {
+        return BattleResponseDTO.AcceptChallengeDTO.builder()
+                .battleId(battle.getId())
+                .firstClositId(battle.getPost1().getUser().getClositId())
+                .firstPostId(battle.getPost1().getId())
+                .firstPostFrontImage(battle.getPost1().getFrontImage())
+                .firstPostBackImage(battle.getPost1().getBackImage())
+                .secondClositId(battle.getPost2().getUser().getClositId())
+                .secondPostId(battle.getPost2().getId())
+                .secondPostFrontImage(battle.getPost2().getFrontImage())
+                .secondPostBackImage(battle.getPost2().getBackImage())
+                .status(battle.getStatus())
                 .build();
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -57,8 +57,8 @@ public class BattleConverter {
                 .build();
     }
 
-    public static BattleResponseDTO.AcceptChallengeDTO acceptChallengeDTO(Battle battle) {
-        return BattleResponseDTO.AcceptChallengeDTO.builder()
+    public static BattleResponseDTO.ChallengeDecisionDTO acceptChallengeDTO(Battle battle) {
+        return BattleResponseDTO.ChallengeDecisionDTO.builder()
                 .battleId(battle.getId())
                 .firstClositId(battle.getPost1().getUser().getClositId())
                 .firstPostId(battle.getPost1().getId())

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -57,19 +57,11 @@ public class BattleConverter {
                 .build();
     }
 
-    public static BattleResponseDTO.ChallengeDecisionDTO acceptChallengeDTO(Battle battle) {
+    public static BattleResponseDTO.ChallengeDecisionDTO challengeDecisionDTO(Battle battle) {
         return BattleResponseDTO.ChallengeDecisionDTO.builder()
-                .battleId(battle.getId())
-                .firstClositId(battle.getPost1().getUser().getClositId())
-                .firstPostId(battle.getPost1().getId())
-                .firstPostFrontImage(battle.getPost1().getFrontImage())
-                .firstPostBackImage(battle.getPost1().getBackImage())
-                .secondClositId(battle.getPost2().getUser().getClositId())
-                .secondPostId(battle.getPost2().getId())
-                .secondPostFrontImage(battle.getPost2().getFrontImage())
-                .secondPostBackImage(battle.getPost2().getBackImage())
                 .status(battle.getStatus())
                 .deadline(battle.getDeadline())
+                .updatedAt(battle.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -28,7 +28,6 @@ public class BattleConverter {
                 .battleId(battle.getId())
                 .thumbnail(battle.getPost1().getFrontImage())
                 .status(battle.getStatus())
-                .deadline(battle.getDeadline())
                 .createdAt(battle.getCreatedAt())
                 .build();
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -69,6 +69,7 @@ public class BattleConverter {
                 .secondPostFrontImage(battle.getPost2().getFrontImage())
                 .secondPostBackImage(battle.getPost2().getBackImage())
                 .status(battle.getStatus())
+                .deadline(battle.getDeadline())
                 .build();
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleRequestDTO.java
@@ -21,7 +21,7 @@ public class BattleRequestDTO {
     }
 
     @Getter
-    public static class AcceptChallengeDTO { // 배틀 신청 수락
+    public static class ChallengeDecisionDTO { // 배틀 신청 수락 or 거절
         @NotNull
         private Long challengeBattleId;
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleRequestDTO.java
@@ -21,6 +21,12 @@ public class BattleRequestDTO {
     }
 
     @Getter
+    public static class AcceptChallengeDTO { // 배틀 신청 수락
+        @NotNull
+        private Long challengeBattleId;
+    }
+
+    @Getter
     public static class VoteBattleDTO { // 배틀 투표
         @NotNull
         private Long postId;

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.domain.battle.dto.BattleDTO;
 
+import UMC_7th.Closit.domain.battle.entity.Status;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +20,7 @@ public class BattleResponseDTO {
     public static class CreateBattleResultDTO { // 배틀 생성
         private Long battleId;
         private String thumbnail;
+        private Status status;
         @JsonFormat(pattern = "yyyy/MM/dd")
         private LocalDate deadline;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
@@ -38,6 +40,7 @@ public class BattleResponseDTO {
         private Long secondPostId;
         private String secondPostFrontImage;
         private String secondPostBackImage;
+        private Status status;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -32,6 +32,7 @@ public class BattleResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChallengeBattleResultDTO { // 배틀 신청
+        private Long challengeBattleId;
         private String firstClositId;
         private Long firstPostId;
         private String firstPostFrontImage;
@@ -43,6 +44,25 @@ public class BattleResponseDTO {
         private Status status;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AcceptChallengeDTO { // 배틀 신청 수락
+        private Long battleId;
+        private String firstClositId;
+        private Long firstPostId;
+        private String firstPostFrontImage;
+        private String firstPostBackImage;
+        private String secondClositId;
+        private Long secondPostId;
+        private String secondPostFrontImage;
+        private String secondPostBackImage;
+        private Status status;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
+        private LocalDateTime updatedAt;
     }
 
     @Builder

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -50,7 +50,7 @@ public class BattleResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class AcceptChallengeDTO { // 배틀 신청 수락
+    public static class ChallengeDecisionDTO { // 배틀 신청 수락 or 거절
         private Long battleId;
         private String firstClositId;
         private Long firstPostId;

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -61,8 +61,7 @@ public class BattleResponseDTO {
         private String secondPostFrontImage;
         private String secondPostBackImage;
         private Status status;
-        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
-        private LocalDateTime updatedAt;
+        private LocalDate deadline;
     }
 
     @Builder

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -51,17 +51,10 @@ public class BattleResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChallengeDecisionDTO { // 배틀 신청 수락 or 거절
-        private Long battleId;
-        private String firstClositId;
-        private Long firstPostId;
-        private String firstPostFrontImage;
-        private String firstPostBackImage;
-        private String secondClositId;
-        private Long secondPostId;
-        private String secondPostFrontImage;
-        private String secondPostBackImage;
         private Status status;
         private LocalDate deadline;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
+        private LocalDateTime updatedAt;
     }
 
     @Builder

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -21,8 +21,6 @@ public class BattleResponseDTO {
         private Long battleId;
         private String thumbnail;
         private Status status;
-        @JsonFormat(pattern = "yyyy/MM/dd")
-        private LocalDate deadline;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
@@ -52,6 +50,7 @@ public class BattleResponseDTO {
     @AllArgsConstructor
     public static class ChallengeDecisionDTO { // 배틀 신청 수락 or 거절
         private Status status;
+        @JsonFormat(pattern = "yyyy/MM/dd")
         private LocalDate deadline;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime updatedAt;

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -25,8 +25,8 @@ public class Battle extends BaseEntity {
     @Column
     private String title;
 
-    @Column(nullable = false)
-    private LocalDate deadline = LocalDate.now().plusDays(3);
+    @Column
+    private LocalDate deadline;
 
     @Column
     @Builder.Default
@@ -82,16 +82,10 @@ public class Battle extends BaseEntity {
         this.status = status;
     }
 
-    public void acceptChallenge(Post post2, Status status) { // 배틀 수락
+    public void acceptChallenge(Post post2, Status status, LocalDate deadline) { // 배틀 수락
         this.post2 = post2;
         this.status = status;
-    }
-
-    @PrePersist
-    public void voteDeadline() { // 배틀 투표 - 마감 기한 3일 뒤 설정
-        if (this.deadline == null) {
-            this.deadline = LocalDate.now().plusDays(3);
-        }
+        this.deadline = deadline;
     }
 
     public boolean availableVote () {

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -5,8 +5,6 @@ import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -15,8 +13,6 @@ import java.util.List;
 @Entity
 @Getter
 @Builder
-@DynamicUpdate
-@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Battle extends BaseEntity {
@@ -50,6 +46,14 @@ public class Battle extends BaseEntity {
     @Builder.Default
     private Integer likeCount = 0;
 
+    @Column
+    @Builder.Default
+    private Integer view = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
     @OneToMany(mappedBy = "battle", cascade = CascadeType.ALL)
     @Builder.Default
     private List<BattleLike> battleLikesList = new ArrayList<>();
@@ -74,8 +78,8 @@ public class Battle extends BaseEntity {
     @JoinColumn(name = "post_id2")
     private Post post2;
 
-    public void setPost2 (Post post2) { // 배틀 신청
-        this.post2 = post2;
+    public void challengeBattle(Status status) { // 배틀 신청
+        this.status = status;
     }
 
     @PrePersist

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -82,6 +82,11 @@ public class Battle extends BaseEntity {
         this.status = status;
     }
 
+    public void acceptChallenge(Post post2, Status status) { // 배틀 수락
+        this.post2 = post2;
+        this.status = status;
+    }
+
     @PrePersist
     public void voteDeadline() { // 배틀 투표 - 마감 기한 3일 뒤 설정
         if (this.deadline == null) {

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
@@ -10,6 +10,12 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(
+        name = "challenge_battle",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_battle_post", columnNames = {"battle_id", "post_id"})
+        }
+)
 public class ChallengeBattle extends BaseEntity {
 
     @Id

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
@@ -34,4 +34,8 @@ public class ChallengeBattle extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
+
+    public void rejectBattle() { // 배틀 거절
+        this.status = Status.REJECTED;
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
@@ -1,0 +1,31 @@
+package UMC_7th.Closit.domain.battle.entity;
+
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChallengeBattle extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "challenge_battle_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "battle_id", nullable = false)
+    private Battle battle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+}

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Status.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Status.java
@@ -1,0 +1,5 @@
+package UMC_7th.Closit.domain.battle.entity;
+
+public enum Status {
+    INACTIVE, PENDING, ACCEPTED, REJECTED, ACTIVE, FINISHED
+}

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Status.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Status.java
@@ -1,5 +1,5 @@
 package UMC_7th.Closit.domain.battle.entity;
 
 public enum Status {
-    INACTIVE, PENDING, ACCEPTED, REJECTED, ACTIVE, FINISHED
+    INACTIVE, PENDING, ACCEPTED, REJECTED, ACTIVE, COMPLETED
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/ChallengeBattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/ChallengeBattleRepository.java
@@ -1,0 +1,7 @@
+package UMC_7th.Closit.domain.battle.repository;
+
+import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeBattleRepository extends JpaRepository<ChallengeBattle, Long> {
+}

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/ChallengeBattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/ChallengeBattleRepository.java
@@ -1,7 +1,16 @@
 package UMC_7th.Closit.domain.battle.repository;
 
+import UMC_7th.Closit.domain.battle.entity.Battle;
 import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChallengeBattleRepository extends JpaRepository<ChallengeBattle, Long> {
+    @Modifying
+    @Query("UPDATE ChallengeBattle cb SET cb.status = " +
+            "CASE WHEN cb.id = :challengeBattleId THEN 'ACCEPTED' ELSE 'REJECTED' END " +
+            "WHERE cb.battle = :battle")
+    int updateBattleStatus(@Param("battle") Battle battle, @Param("challengeBattleId") Long challengeBattleId);
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
@@ -9,6 +9,7 @@ public interface BattleCommandService {
 
     Battle createBattle(Long userId, BattleRequestDTO.CreateBattleDTO request); // 배틀 생성
     ChallengeBattle challengeBattle(Long userId, Long battleId, BattleRequestDTO.ChallengeBattleDTO request); // 배틀 신청
+    Battle acceptChallenge(Long userId, Long battleId, BattleRequestDTO.AcceptChallengeDTO request); // 배틀 수락
     Vote voteBattle(Long userId, Long battleId, BattleRequestDTO.VoteBattleDTO request); // 배틀 투표
     void deleteBattle(Long userId, Long battleId); // 배틀 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
@@ -2,12 +2,13 @@ package UMC_7th.Closit.domain.battle.service.BattleService;
 
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleRequestDTO;
 import UMC_7th.Closit.domain.battle.entity.Battle;
+import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
 import UMC_7th.Closit.domain.battle.entity.Vote;
 
 public interface BattleCommandService {
 
     Battle createBattle(Long userId, BattleRequestDTO.CreateBattleDTO request); // 배틀 생성
-    Battle challengeBattle(Long userId, Long battleId, BattleRequestDTO.ChallengeBattleDTO request); // 배틀 신청
+    ChallengeBattle challengeBattle(Long userId, Long battleId, BattleRequestDTO.ChallengeBattleDTO request); // 배틀 신청
     Vote voteBattle(Long userId, Long battleId, BattleRequestDTO.VoteBattleDTO request); // 배틀 투표
     void deleteBattle(Long userId, Long battleId); // 배틀 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
@@ -10,6 +10,7 @@ public interface BattleCommandService {
     Battle createBattle(Long userId, BattleRequestDTO.CreateBattleDTO request); // 배틀 생성
     ChallengeBattle challengeBattle(Long userId, Long battleId, BattleRequestDTO.ChallengeBattleDTO request); // 배틀 신청
     Battle acceptChallenge(Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request); // 배틀 수락
+    Battle rejectChallenge(Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request); // 배틀 거절
     Vote voteBattle(Long userId, Long battleId, BattleRequestDTO.VoteBattleDTO request); // 배틀 투표
     void deleteBattle(Long userId, Long battleId); // 배틀 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
@@ -9,7 +9,7 @@ public interface BattleCommandService {
 
     Battle createBattle(Long userId, BattleRequestDTO.CreateBattleDTO request); // 배틀 생성
     ChallengeBattle challengeBattle(Long userId, Long battleId, BattleRequestDTO.ChallengeBattleDTO request); // 배틀 신청
-    Battle acceptChallenge(Long userId, Long battleId, BattleRequestDTO.AcceptChallengeDTO request); // 배틀 수락
+    Battle acceptChallenge(Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request); // 배틀 수락
     Vote voteBattle(Long userId, Long battleId, BattleRequestDTO.VoteBattleDTO request); // 배틀 투표
     void deleteBattle(Long userId, Long battleId); // 배틀 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -63,7 +63,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
     }
 
     @Override
-    public Battle acceptChallenge (Long userId, Long battleId, BattleRequestDTO.AcceptChallengeDTO request) { // 배틀 수락
+    public Battle acceptChallenge (Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request) { // 배틀 수락
         Battle battle = battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -78,6 +78,19 @@ public class BattleCommandServiceImpl implements BattleCommandService {
     }
 
     @Override
+    public Battle rejectChallenge (Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request) { // 배틀 신청
+        Battle battle = battleRepository.findById(battleId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
+
+        ChallengeBattle challengeBattle = challengeBattleRepository.findById(request.getChallengeBattleId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_BATTLE_NOT_FOUND));
+
+        challengeBattle.rejectBattle();
+
+        return battle;
+    }
+
+    @Override
     public Vote voteBattle (Long userId, Long battleId, BattleRequestDTO.VoteBattleDTO request) { // 배틀 투표
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -43,7 +43,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
 
         // 본인의 게시글이 아닐 경우, 배틀 게시글로 업로드 불가능
         if (!post.getUser().getId().equals(userId)) {
-            throw new GeneralException(ErrorStatus.POST_NOT_MINE);
+            throw new GeneralException(ErrorStatus.POST_UNAUTHORIZED_ACCESS);
         }
 
         return battleRepository.save(battle);
@@ -166,7 +166,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
 
         // 배틀 게시글을 생성한 이가 아닐 경우 , 삭제 불가능
         if (!battle.getPost1().getUser().getId().equals(userId)) {
-            throw new GeneralException(ErrorStatus.POST_NOT_MINE);
+            throw new GeneralException(ErrorStatus.POST_UNAUTHORIZED_ACCESS);
         }
 
         battleRepository.delete(battle);
@@ -190,7 +190,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
 
         // 본인의 게시글이 아닐 경우, 배틀 신청 불가능
         if (!post.getUser().getId().equals(userId)) {
-            throw new GeneralException(ErrorStatus.POST_NOT_MINE);
+            throw new GeneralException(ErrorStatus.POST_UNAUTHORIZED_ACCESS);
         }
 
         // Status = INACTIVE일 경우에만 배틀 신청 가능

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -53,32 +53,9 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         Post post = postRepository.findById(request.getPostId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
 
+        validateChallengeBattle(battle, post, userId, request.getPostId());
+
         ChallengeBattle challengeBattle = BattleConverter.toChallengeBattle(battle, post);
-
-        // 동일한 게시글로 배틀 불가능
-        if (request.getPostId().equals(battle.getPost1().getId())) {
-            throw new GeneralException(ErrorStatus.BATTLE_NOT_CHALLENGE);
-        }
-
-        // 배틀 형성 완료 -> 신청 불가능
-        if (battle.getPost2() != null) {
-            throw new GeneralException(ErrorStatus.BATTLE_ALREADY_EXIST);
-        }
-
-        // 내 게시글에 배틀 신청 불가능
-        if (battle.getPost1().getUser().getId().equals(userId)) {
-            throw new GeneralException(ErrorStatus.POST_NOT_APPLY);
-        }
-
-        // 본인의 게시글이 아닐 경우, 배틀 신청 불가능
-        if (!post.getUser().getId().equals(userId)) {
-            throw new GeneralException(ErrorStatus.POST_NOT_MINE);
-        }
-
-        // Status = INACTIVE일 경우에만 배틀 신청 가능
-        if (battle.getStatus().equals(Status.INACTIVE)) {
-            battle.challengeBattle(Status.PENDING);
-        }
 
         return challengeBattleRepository.save(challengeBattle);
     }
@@ -151,5 +128,32 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         }
 
         battleRepository.delete(battle);
+    }
+
+    private void validateChallengeBattle(Battle battle, Post post, Long userId, Long request) {
+        // 동일한 게시글로 배틀 불가능
+        if (request.equals(battle.getPost1().getId())) {
+            throw new GeneralException(ErrorStatus.BATTLE_NOT_CHALLENGE);
+        }
+
+        // 배틀 형성 완료 -> 신청 불가능
+        if (battle.getPost2() != null) {
+            throw new GeneralException(ErrorStatus.BATTLE_ALREADY_EXIST);
+        }
+
+        // 내 게시글에 배틀 신청 불가능
+        if (battle.getPost1().getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.POST_NOT_APPLY);
+        }
+
+        // 본인의 게시글이 아닐 경우, 배틀 신청 불가능
+        if (!post.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.POST_NOT_MINE);
+        }
+
+        // Status = INACTIVE일 경우에만 배틀 신청 가능
+        if (battle.getStatus().equals(Status.INACTIVE)) {
+            battle.challengeBattle(Status.PENDING);
+        }
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -76,6 +76,10 @@ public class BattleCommandServiceImpl implements BattleCommandService {
 
         challengeBattleRepository.updateBattleStatus(battle, challengeBattle.getId());
 
+        // Post1 게시글 작성자만 수락 가능
+        if (!battle.getPost1().getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.BATTLE_UNAUTHORIZED_ACCESS);
+        }
         battle.acceptChallenge(challengeBattle.getPost(), Status.ACTIVE, LocalDate.now().plusDays(3));
 
         return battleRepository.save(battle);
@@ -89,6 +93,10 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         ChallengeBattle challengeBattle = challengeBattleRepository.findById(request.getChallengeBattleId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_BATTLE_NOT_FOUND));
 
+        // Post1 게시글 작성자만 거절 가능
+        if (!battle.getPost1().getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.BATTLE_UNAUTHORIZED_ACCESS);
+        }
         challengeBattle.rejectBattle();
 
         return battle;

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -61,6 +61,21 @@ public class BattleCommandServiceImpl implements BattleCommandService {
     }
 
     @Override
+    public Battle acceptChallenge (Long userId, Long battleId, BattleRequestDTO.AcceptChallengeDTO request) { // 배틀 수락
+        Battle battle = battleRepository.findById(battleId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
+
+        ChallengeBattle challengeBattle = challengeBattleRepository.findById(request.getChallengeBattleId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_BATTLE_NOT_FOUND));
+
+        challengeBattleRepository.updateBattleStatus(battle, challengeBattle.getId());
+
+        battle.acceptChallenge(challengeBattle.getPost(), Status.ACTIVE);
+
+        return battleRepository.save(battle);
+    }
+
+    @Override
     public Vote voteBattle (Long userId, Long battleId, BattleRequestDTO.VoteBattleDTO request) { // 배틀 투표
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -9,6 +9,7 @@ import UMC_7th.Closit.domain.battle.entity.Vote;
 import UMC_7th.Closit.domain.battle.repository.BattleRepository;
 import UMC_7th.Closit.domain.battle.repository.ChallengeBattleRepository;
 import UMC_7th.Closit.domain.battle.repository.VoteRepository;
+import UMC_7th.Closit.domain.notification.service.NotiCommandService;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.post.repository.PostRepository;
 import UMC_7th.Closit.domain.user.entity.User;
@@ -31,6 +32,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
     private final PostRepository postRepository;
     private final VoteRepository voteRepository;
     private final UserRepository userRepository;
+    private final NotiCommandService notiCommandService;
 
     @Override
     public Battle createBattle (Long userId, BattleRequestDTO.CreateBattleDTO request) { // 배틀 생성
@@ -58,6 +60,8 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         validateChallengeBattle(battle, post, userId, request.getPostId());
 
         ChallengeBattle challengeBattle = BattleConverter.toChallengeBattle(battle, post);
+
+        notiCommandService.challengeBattleNotification(challengeBattle);
 
         return challengeBattleRepository.save(challengeBattle);
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -19,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -70,7 +72,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
 
         challengeBattleRepository.updateBattleStatus(battle, challengeBattle.getId());
 
-        battle.acceptChallenge(challengeBattle.getPost(), Status.ACTIVE);
+        battle.acceptChallenge(challengeBattle.getPost(), Status.ACTIVE, LocalDate.now().plusDays(3));
 
         return battleRepository.save(battle);
     }

--- a/src/main/java/UMC_7th/Closit/domain/notification/entity/NotificationType.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/entity/NotificationType.java
@@ -10,5 +10,7 @@ public enum NotificationType {
     @Schema(description = "팔로우 알림")
     FOLLOW,
     @Schema(description = "미션 알림")
-    MISSION;
+    MISSION,
+    @Schema(description = "배틀 신청 알림")
+    CHALLENGE_BATTLE
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandService.java
@@ -1,13 +1,12 @@
 package UMC_7th.Closit.domain.notification.service;
 
+import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
 import UMC_7th.Closit.domain.follow.entity.Follow;
 import UMC_7th.Closit.domain.notification.dto.NotificationRequestDTO;
 import UMC_7th.Closit.domain.notification.entity.Notification;
 import UMC_7th.Closit.domain.post.entity.Comment;
 import UMC_7th.Closit.domain.post.entity.Likes;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.util.List;
 
 public interface NotiCommandService {
     SseEmitter subscribe (Long userId, String lastEventId); // SSE 연결
@@ -17,5 +16,6 @@ public interface NotiCommandService {
     void likeNotification(Likes likes); // 좋아요 알림
     void followNotification(Follow follow); // 팔로우 알림
     void missionNotification(SseEmitter emitter, String emitterId, Object data); // 미션 알림
+    void challengeBattleNotification(ChallengeBattle challengeBattle); // 배틀 신청 알림
     void deleteNotification(Long userId, Long notificationId); // 알림 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.domain.notification.service;
 
+import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
 import UMC_7th.Closit.domain.follow.entity.Follow;
 import UMC_7th.Closit.domain.notification.converter.NotificationConverter;
 import UMC_7th.Closit.domain.notification.dto.NotificationRequestDTO;
@@ -171,6 +172,18 @@ public class NotiCommandServiceImpl implements NotiCommandService {
                 sendToClient(emitter, emitterId, content.getBytes(StandardCharsets.UTF_8));
             } scheduler.shutdown(); // 작업 완료 후, 스레드 종료
         }, 10, TimeUnit.SECONDS); // SSE 연결 10초 후, 한 번만 실행
+    }
+
+    @Override
+    public void challengeBattleNotification(ChallengeBattle challengeBattle) {
+        User receiver = challengeBattle.getBattle().getPost1().getUser();
+        User sender = challengeBattle.getPost().getUser();
+        String content = challengeBattle.getPost().getUser().getName() + "님이 배틀을 신청하셨습니다.";
+        String url = URL + "/communities/battle/challenge/upload/" + challengeBattle.getBattle().getId();
+
+        NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, sender, content, url, NotificationType.CHALLENGE_BATTLE);
+
+        sendNotification(request);
     }
 
     @Override

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,9 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_NOT_APPLY(HttpStatus.BAD_REQUEST, "BATTLE4007", "본인의 게시글에 배틀을 신청할 수 없습니다."),
     POST_NOT_MINE(HttpStatus.BAD_REQUEST, "BATTLE4008", "해당 게시글은 다른 사용자의 게시글입니다."),
 
+    // 챌린지 배틀 관련 에러
+    CHALLENGE_BATTLE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGEBATTLE4041", "챌린지 배틀이 존재하지 않습니다."),
+
     // 투표 관련 에러
     VOTE_ALREADY_EXIST (HttpStatus.BAD_REQUEST, "VOTE4001", "이미 투표를 했습니다."),
     VOTE_EXPIRED (HttpStatus.BAD_REQUEST, "VOTE4002", "이미 종료된 투표 입니다."),

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -61,7 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_IS_CHALLENGE (HttpStatus.BAD_REQUEST, "BATTLE4005", "해당 게시글은 배틀 챌린지 게시글입니다."),
     BATTLE_NOT_FOUND (HttpStatus.NOT_FOUND, "BATTLE4041", "배틀이 존재하지 않습니다."),
     POST_NOT_APPLY(HttpStatus.BAD_REQUEST, "BATTLE4007", "본인의 게시글에 배틀을 신청할 수 없습니다."),
-    POST_NOT_MINE(HttpStatus.BAD_REQUEST, "BATTLE4008", "해당 게시글은 다른 사용자의 게시글입니다."),
+    POST_UNAUTHORIZED_ACCESS(HttpStatus.BAD_REQUEST, "BATTLE4008", "해당 게시글은 다른 사용자의 게시글입니다."),
     BATTLE_UNAUTHORIZED_ACCESS(HttpStatus.BAD_REQUEST, "BATTLE4009", "해당 배틀 게시글은 다른 사용자의 배틀 게시글 입니다."),
 
     // 챌린지 배틀 관련 에러

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -62,6 +62,7 @@ public enum ErrorStatus implements BaseErrorCode {
     BATTLE_NOT_FOUND (HttpStatus.NOT_FOUND, "BATTLE4041", "배틀이 존재하지 않습니다."),
     POST_NOT_APPLY(HttpStatus.BAD_REQUEST, "BATTLE4007", "본인의 게시글에 배틀을 신청할 수 없습니다."),
     POST_NOT_MINE(HttpStatus.BAD_REQUEST, "BATTLE4008", "해당 게시글은 다른 사용자의 게시글입니다."),
+    BATTLE_UNAUTHORIZED_ACCESS(HttpStatus.BAD_REQUEST, "BATTLE4009", "해당 배틀 게시글은 다른 사용자의 배틀 게시글 입니다."),
 
     // 챌린지 배틀 관련 에러
     CHALLENGE_BATTLE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGEBATTLE4041", "챌린지 배틀이 존재하지 않습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #211 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 배틀 신청 로직 수정 (초기 상태 = INACTIVE, 배틀 생성 후 상태 = ACTIVE)
- 배틀 신청 수락, 거절 API
- 배틀 신청 시, 알림 SSE 알림 전송

## 📸 스크린샷
- 배틀 신청 로직 수정 (상태 = PENDING)
![스크린샷 2025-04-07 011440](https://github.com/user-attachments/assets/c5c5e589-1c8a-47c9-bf9a-f0a3972be061)
- 배틀 신청 수락 (챌린지 배틀 상태 = ACCEPTED, 배틀 상태 = ACTIVE)
![스크린샷 2025-04-07 011029](https://github.com/user-attachments/assets/f0115433-1dcb-471e-afdb-f2240cecda1f)
- 배틀 신청 거절 (챌린지 배틀 상태 = REJECTED, 배틀 상태 = PENDING)
![스크린샷 2025-04-07 012223](https://github.com/user-attachments/assets/82372020-787c-40f5-aa73-db2adcccfb5d)
- 배틀 신청 알림 전송
![스크린샷 2025-04-07 010908](https://github.com/user-attachments/assets/6ddfb5e9-9719-44bd-9d66-07c26850d85e)

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
