### PR TITLE
feat: 배틀 조회 정렬

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-template.md
@@ -2,7 +2,7 @@
 name: Bug Report Template
 about: '버그 리포트 이슈 템플릿 '
 title: 'fix: '
-labels: ['🚨hotfix']
+labels: ['🐛bug']
 assignees: ''
 
 ---

--- a/src/main/java/UMC_7th/Closit/ClositApplication.java
+++ b/src/main/java/UMC_7th/Closit/ClositApplication.java
@@ -4,10 +4,13 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class ClositApplication {
 
 	@PostConstruct

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -126,12 +126,14 @@ public class BattleController {
             ## 배틀 게시글 목록 조회 - 투표 하지 않은 배틀 게시글은 0으로 보임
             ### Parameters
             page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌 \n
-            status [배틀 진행 상태] - 
+            battleSorting [배틀 정렬 방식] - 최신순 (LATEST), 인기순 (TRENDING) \n
+            battleStatus [배틀 진행 상태] - 진행 중 (ACTIVE), 종료 (COMPLETED)
             """)
     public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getBattleList(@RequestParam(name = "page") Integer page,
-                                                                             @RequestParam(name = "battleStatus")BattleStatus battleStatus) {
+                                                                             @RequestParam(name ="battleSorting") BattleSorting battleSorting,
+                                                                             @RequestParam(name = "battleStatus") BattleStatus battleStatus) {
 
-        Slice<Battle> battleList = battleQueryService.getBattleList(page, battleStatus);
+        Slice<Battle> battleList = battleQueryService.getBattleList(page, battleSorting, battleStatus);
 
         return ApiResponse.onSuccess(BattleConverter.battlePreviewListDTO(battleList));
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -128,14 +128,14 @@ public class BattleController {
             ## 배틀 게시글 목록 조회 - 투표 하지 않은 배틀 게시글은 0으로 보임
             ### Parameters
             page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌 \n
-            battleSorting [배틀 정렬 방식] - 최신순 (LATEST), 인기순 (TRENDING) \n
-            battleStatus [배틀 진행 상태] - 진행 중 (ACTIVE), 종료 (COMPLETED)
+            sorting [배틀 정렬 방식] - 최신순 (LATEST), 인기순 (TRENDING) \n
+            status [배틀 진행 상태] - 진행 중 (ACTIVE), 종료 (COMPLETED)
             """)
     public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getBattleList(@RequestParam(name = "page") Integer page,
-                                                                             @RequestParam(name ="battleSorting") BattleSorting battleSorting,
-                                                                             @RequestParam(name = "battleStatus") BattleStatus battleStatus) {
+                                                                             @RequestParam(name ="sorting") BattleSorting sorting,
+                                                                             @RequestParam(name = "status") BattleStatus status) {
 
-        Slice<Battle> battleList = battleQueryService.getBattleList(page, battleSorting, battleStatus);
+        Slice<Battle> battleList = battleQueryService.getBattleList(page, sorting, status);
 
         return ApiResponse.onSuccess(BattleConverter.battlePreviewListDTO(battleList));
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -3,9 +3,7 @@ package UMC_7th.Closit.domain.battle.controller;
 import UMC_7th.Closit.domain.battle.converter.BattleConverter;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleRequestDTO;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleResponseDTO;
-import UMC_7th.Closit.domain.battle.entity.Battle;
-import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
-import UMC_7th.Closit.domain.battle.entity.Vote;
+import UMC_7th.Closit.domain.battle.entity.*;
 import UMC_7th.Closit.domain.battle.service.BattleService.BattleCommandService;
 import UMC_7th.Closit.domain.battle.service.BattleService.BattleQueryService;
 import UMC_7th.Closit.domain.user.entity.User;
@@ -128,8 +126,10 @@ public class BattleController {
             ## 배틀 게시글 목록 조회 - 투표 하지 않은 배틀 게시글은 0으로 보임
             ### Parameters
             page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌
+            status [배틀 진행 상태] - 
             """)
-    public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getBattleList(@RequestParam(name = "page") Integer page) {
+    public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getBattleList(@RequestParam(name = "page") Integer page,
+                                                                             @RequestParam(name = "battleStatus")BattleStatus battleStatus) {
 
         Slice<Battle> battleList = battleQueryService.getBattleList(page);
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -10,11 +10,13 @@ import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
 import UMC_7th.Closit.security.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "[배틀 게시판]", description = "배틀 게시판 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth/communities/battle")

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -125,13 +125,13 @@ public class BattleController {
             description = """
             ## 배틀 게시글 목록 조회 - 투표 하지 않은 배틀 게시글은 0으로 보임
             ### Parameters
-            page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌
+            page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌 \n
             status [배틀 진행 상태] - 
             """)
     public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getBattleList(@RequestParam(name = "page") Integer page,
                                                                              @RequestParam(name = "battleStatus")BattleStatus battleStatus) {
 
-        Slice<Battle> battleList = battleQueryService.getBattleList(page);
+        Slice<Battle> battleList = battleQueryService.getBattleList(page, battleStatus);
 
         return ApiResponse.onSuccess(BattleConverter.battlePreviewListDTO(battleList));
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -152,7 +152,7 @@ public class BattleController {
         return ApiResponse.onSuccess(BattleConverter.challengeBattlePreviewListDTO(challengeBattleList));
     }
 
-    @GetMapping("/my-voted-posts")
+    @GetMapping("/voted-posts")
     @Operation(summary = "내가 투표한 게시글 목록 조회",
             description = """
             ## 내가 투표한 배틀 게시글 목록 조회

--- a/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/controller/BattleController.java
@@ -152,6 +152,20 @@ public class BattleController {
         return ApiResponse.onSuccess(BattleConverter.challengeBattlePreviewListDTO(challengeBattleList));
     }
 
+    @GetMapping("/my-voted-posts")
+    @Operation(summary = "내가 투표한 게시글 목록 조회",
+            description = """
+            ## 내가 투표한 배틀 게시글 목록 조회
+            ### Parameters
+            page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌
+            """)
+    public ApiResponse<BattleResponseDTO.BattlePreviewListDTO> getMyVotedPostList(@RequestParam(name = "page") Integer page) {
+
+        Slice<Battle> votedBattleList = battleQueryService.getMyVotedBattleList(page);
+
+        return ApiResponse.onSuccess(BattleConverter.battlePreviewListDTO(votedBattleList));
+    }
+
     @DeleteMapping("/{battle_id}")
     @Operation(summary = "배틀 삭제",
             description = """

--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -2,10 +2,7 @@ package UMC_7th.Closit.domain.battle.converter;
 
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleRequestDTO;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleResponseDTO;
-import UMC_7th.Closit.domain.battle.entity.Battle;
-import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
-import UMC_7th.Closit.domain.battle.entity.Status;
-import UMC_7th.Closit.domain.battle.entity.Vote;
+import UMC_7th.Closit.domain.battle.entity.*;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.domain.Slice;
@@ -19,7 +16,7 @@ public class BattleConverter {
         return Battle.builder()
                 .post1(post)
                 .title(request.getTitle())
-                .status(Status.INACTIVE)
+                .battleStatus(BattleStatus.INACTIVE)
                 .build();
     }
 
@@ -27,7 +24,7 @@ public class BattleConverter {
         return BattleResponseDTO.CreateBattleResultDTO.builder()
                 .battleId(battle.getId())
                 .thumbnail(battle.getPost1().getFrontImage())
-                .status(battle.getStatus())
+                .battleStatus(battle.getBattleStatus())
                 .createdAt(battle.getCreatedAt())
                 .build();
     }
@@ -36,7 +33,7 @@ public class BattleConverter {
         return ChallengeBattle.builder()
                 .battle(battle)
                 .post(post)
-                .status(Status.PENDING)
+                .challengeStatus(ChallengeStatus.PENDING)
                 .build();
     }
 
@@ -51,14 +48,14 @@ public class BattleConverter {
                 .secondPostId(challengeBattle.getPost().getId())
                 .secondPostFrontImage(challengeBattle.getPost().getFrontImage())
                 .secondPostBackImage(challengeBattle.getPost().getBackImage())
-                .status(challengeBattle.getStatus())
+                .challengeStatus(challengeBattle.getChallengeStatus())
                 .createdAt(challengeBattle.getCreatedAt())
                 .build();
     }
 
     public static BattleResponseDTO.ChallengeDecisionDTO challengeDecisionDTO(Battle battle) {
         return BattleResponseDTO.ChallengeDecisionDTO.builder()
-                .status(battle.getStatus())
+                .battleStatus(battle.getBattleStatus())
                 .deadline(battle.getDeadline())
                 .updatedAt(battle.getUpdatedAt())
                 .build();

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -51,8 +50,8 @@ public class BattleResponseDTO {
     @AllArgsConstructor
     public static class ChallengeDecisionDTO { // 배틀 신청 수락 or 거절
         private BattleStatus battleStatus;
-        @JsonFormat(pattern = "yyyy/MM/dd")
-        private LocalDate deadline;
+        @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
+        private LocalDateTime deadline;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime updatedAt;
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -75,7 +75,7 @@ public class BattleResponseDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class BattlePreviewDTO { // 배틀 게시글 목록 조회
+    public static class BattlePreviewDTO { // 배틀 게시글 목록, 내가 투표한 게시글 목록 조회
         private Long battleId;
         private boolean isLiked;
         private String title;

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -1,6 +1,7 @@
 package UMC_7th.Closit.domain.battle.dto.BattleDTO;
 
-import UMC_7th.Closit.domain.battle.entity.Status;
+import UMC_7th.Closit.domain.battle.entity.BattleStatus;
+import UMC_7th.Closit.domain.battle.entity.ChallengeStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,7 @@ public class BattleResponseDTO {
     public static class CreateBattleResultDTO { // 배틀 생성
         private Long battleId;
         private String thumbnail;
-        private Status status;
+        private BattleStatus battleStatus;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
@@ -39,7 +40,7 @@ public class BattleResponseDTO {
         private Long secondPostId;
         private String secondPostFrontImage;
         private String secondPostBackImage;
-        private Status status;
+        private ChallengeStatus challengeStatus;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
@@ -49,7 +50,7 @@ public class BattleResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChallengeDecisionDTO { // 배틀 신청 수락 or 거절
-        private Status status;
+        private BattleStatus battleStatus;
         @JsonFormat(pattern = "yyyy/MM/dd")
         private LocalDate deadline;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -95,19 +95,13 @@ public class Battle extends BaseEntity {
         this.secondVotingCnt++;
     }
 
-    public void setFirstVotingCnt (Integer firstVotingCnt) { // 배틀 게시글 목록 조회
+    public void updateVotingCnt(Integer firstVotingCnt, Integer secondVotingCnt) { // 배틀 게시글 목록 조회
         this.firstVotingCnt = firstVotingCnt;
-    }
-
-    public void setSecondVotingCnt (Integer secondVotingCnt) {
         this.secondVotingCnt = secondVotingCnt;
     }
 
-    public void setFirstVotingRate (double firstVotingRate) {
+    public void updateVotingRate (double firstVotingRate, double secondVotingRate) {
         this.firstVotingRate = firstVotingRate;
-    }
-
-    public void setSecondVotingRate (double secondVotingRate) {
         this.secondVotingRate = secondVotingRate;
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -5,7 +5,7 @@ import UMC_7th.Closit.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,7 +25,7 @@ public class Battle extends BaseEntity {
     private String title;
 
     @Column
-    private LocalDate deadline;
+    private LocalDateTime deadline;
 
     @Column
     @Builder.Default
@@ -77,14 +77,18 @@ public class Battle extends BaseEntity {
         this.battleStatus = BattleStatus.PENDING;
     }
 
-    public void acceptChallenge(Post post2, LocalDate deadline) { // 배틀 수락
+    public void acceptChallenge(Post post2, LocalDateTime deadline) { // 배틀 수락
         this.post2 = post2;
         this.battleStatus = BattleStatus.ACTIVE;
         this.deadline = deadline;
     }
 
+    public void completeBattle() { // 배틀 스케줄러 - 진행 상태 변경
+        this.battleStatus = BattleStatus.COMPLETED;
+    }
+
     public boolean availableVote () {
-        return LocalDate.now().isAfter(deadline);
+        return LocalDateTime.now().isAfter(deadline);
     }
 
     public void incrementFirstVotingCnt() { // 첫 번째 게시글 투표

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -110,11 +110,7 @@ public class Battle extends BaseEntity {
     }
 
     public void increaseLikeCount() { // 배틀 좋아요 생성
-        if (this.likeCount == null) {
-            this.likeCount = 1;
-        } else {
-            this.likeCount++;
-        }
+        this.likeCount++;
     }
 
     public void decreaseLikeCount() { // 배틀 좋아요 삭제

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -47,7 +47,7 @@ public class Battle extends BaseEntity {
 
     @Column
     @Builder.Default
-    private Integer view = 0;
+    private Integer viewCount = 0;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -123,5 +123,9 @@ public class Battle extends BaseEntity {
         } else {
             this.likeCount--;
         }
+    }
+
+    public void increaseView() { // 배틀 조회수 증가
+        this.viewCount++;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -51,7 +51,7 @@ public class Battle extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Status status;
+    private BattleStatus battleStatus;
 
     @OneToMany(mappedBy = "battle", cascade = CascadeType.ALL)
     @Builder.Default
@@ -73,13 +73,13 @@ public class Battle extends BaseEntity {
     @JoinColumn(name = "post_id2")
     private Post post2;
 
-    public void challengeBattle(Status status) { // 배틀 신청
-        this.status = status;
+    public void challengeBattle() { // 배틀 신청
+        this.battleStatus = BattleStatus.PENDING;
     }
 
-    public void acceptChallenge(Post post2, Status status, LocalDate deadline) { // 배틀 수락
+    public void acceptChallenge(Post post2, LocalDate deadline) { // 배틀 수락
         this.post2 = post2;
-        this.status = status;
+        this.battleStatus = BattleStatus.ACTIVE;
         this.deadline = deadline;
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleSorting.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleSorting.java
@@ -1,0 +1,16 @@
+package UMC_7th.Closit.domain.battle.entity;
+
+import lombok.Getter;
+import org.springframework.data.domain.Sort;
+
+@Getter
+public enum BattleSorting {
+    LATEST(Sort.by(Sort.Direction.DESC, "createdAt")),
+    TRENDING(Sort.by(Sort.Direction.DESC, "view"));
+
+    private final Sort sort;
+
+    BattleSorting(Sort sort) {
+        this.sort = sort;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleSorting.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleSorting.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Sort;
 @Getter
 public enum BattleSorting {
     LATEST(Sort.by(Sort.Direction.DESC, "createdAt")),
-    TRENDING(Sort.by(Sort.Direction.DESC, "view"));
+    TRENDING(Sort.by(Sort.Direction.DESC, "viewCount"));
 
     private final Sort sort;
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleStatus.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleStatus.java
@@ -1,0 +1,5 @@
+package UMC_7th.Closit.domain.battle.entity;
+
+public enum BattleStatus {
+    INACTIVE, PENDING, ACTIVE, COMPLETED
+}

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeBattle.java
@@ -25,7 +25,7 @@ public class ChallengeBattle extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Status status;
+    private ChallengeStatus challengeStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "battle_id", nullable = false)
@@ -36,6 +36,6 @@ public class ChallengeBattle extends BaseEntity {
     private Post post;
 
     public void rejectBattle() { // 배틀 거절
-        this.status = Status.REJECTED;
+        this.challengeStatus = ChallengeStatus.REJECTED;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeStatus.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/ChallengeStatus.java
@@ -1,0 +1,5 @@
+package UMC_7th.Closit.domain.battle.entity;
+
+public enum ChallengeStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Status.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Status.java
@@ -1,5 +1,0 @@
-package UMC_7th.Closit.domain.battle.entity;
-
-public enum Status {
-    INACTIVE, PENDING, ACCEPTED, REJECTED, ACTIVE, COMPLETED
-}

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Vote.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Vote.java
@@ -4,14 +4,10 @@ import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
 @Builder
-@DynamicUpdate
-@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Vote extends BaseEntity {
@@ -32,15 +28,9 @@ public class Vote extends BaseEntity {
     @JoinColumn(name = "battle_id")
     private Battle battle;
 
-    public void setUser (Long userId) { // 배틀 투표
+    public void voteBattle(User user, Battle battle, Long votedPostId) { // 배틀 투표
         this.user = user;
-    }
-
-    public void setBattle (Battle battle) {
         this.battle = battle;
-    }
-
-    public void setVotedPostId (Long postId) {
         this.votedPostId = votedPostId;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
@@ -2,9 +2,12 @@ package UMC_7th.Closit.domain.battle.repository;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
 import UMC_7th.Closit.domain.battle.entity.BattleStatus;
+import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +15,13 @@ public interface BattleRepository extends JpaRepository<Battle,Long> {
     Optional<Battle> findById(Long battleId);
     Slice<Battle> findByPost2IsNotNullAndBattleStatus(Pageable pageable, BattleStatus battleStatus); // 배틀 게시글 목록 조회
     Slice<Battle> findByPost2IsNull(Pageable pageable); // 배틀 챌린지 게시글 목록 조회
+    @Query("""
+        select b from Battle b
+        where b.post2 is not null
+        and b in (
+            select v.battle from Vote v
+            where v.user = :user
+        )
+    """)
+    Slice<Battle> findVotedBattlesByUserAndPost2IsNotNull(@Param("user") User user, Pageable pageable); // 내가 투표한 게시글 목록 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
@@ -1,6 +1,7 @@
 package UMC_7th.Closit.domain.battle.repository;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
+import UMC_7th.Closit.domain.battle.entity.BattleStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +10,6 @@ import java.util.Optional;
 
 public interface BattleRepository extends JpaRepository<Battle,Long> {
     Optional<Battle> findById(Long battleId);
-    Slice<Battle> findByPost2IsNotNull(Pageable pageable); // 배틀 게시글 목록 조회
+    Slice<Battle> findByPost2IsNotNullAndBattleStatus(Pageable pageable, BattleStatus battleStatus); // 배틀 게시글 목록 조회
     Slice<Battle> findByPost2IsNull(Pageable pageable); // 배틀 챌린지 게시글 목록 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface BattleRepository extends JpaRepository<Battle,Long> {
@@ -24,4 +25,5 @@ public interface BattleRepository extends JpaRepository<Battle,Long> {
         )
     """)
     Slice<Battle> findVotedBattlesByUserAndPost2IsNotNull(@Param("user") User user, Pageable pageable); // 내가 투표한 게시글 목록 조회
+    Slice<Battle> findByBattleStatusAndDeadlineIsNotNullAndDeadlineBefore(BattleStatus battleStatus, LocalDateTime deadline, Pageable pageable); // 배틀 스케줄러 - 진행 상태 변경
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/ChallengeBattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/ChallengeBattleRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChallengeBattleRepository extends JpaRepository<ChallengeBattle, Long> {
     @Modifying
-    @Query("UPDATE ChallengeBattle cb SET cb.status = " +
+    @Query("UPDATE ChallengeBattle cb SET cb.challengeStatus = " +
             "CASE WHEN cb.id = :challengeBattleId THEN 'ACCEPTED' ELSE 'REJECTED' END " +
             "WHERE cb.battle = :battle")
-    int updateBattleStatus(@Param("battle") Battle battle, @Param("challengeBattleId") Long challengeBattleId);
+    int updateChallengeStatus(@Param("battle") Battle battle, @Param("challengeBattleId") Long challengeBattleId);
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/scheduler/BattleScheduler.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/scheduler/BattleScheduler.java
@@ -1,0 +1,21 @@
+package UMC_7th.Closit.domain.battle.scheduler;
+
+import UMC_7th.Closit.domain.battle.service.BattleService.BattleCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BattleScheduler {
+
+    private final BattleCommandService battleCommandService;
+
+    // 매일 자정마다 실행
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateBattleStatus() {
+        battleCommandService.completeBattle();
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandService.java
@@ -12,5 +12,6 @@ public interface BattleCommandService {
     Battle acceptChallenge(Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request); // 배틀 수락
     Battle rejectChallenge(Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request); // 배틀 거절
     Vote voteBattle(Long userId, Long battleId, BattleRequestDTO.VoteBattleDTO request); // 배틀 투표
+    void completeBattle(); // 배틀 진행 상태 갱신
     void deleteBattle(Long userId, Long battleId); // 배틀 삭제
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -201,7 +201,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
 
     private void validateVoteBattle(Battle battle, Long userId, BattleRequestDTO.VoteBattleDTO request) {
         // 배틀이 아닌 게시글에 투표 불가능
-        if (!battle.getPost1().getId().equals(request.getPostId()) && !battle.getPost2().getId().equals(request.getPostId())) {
+        if (isInvalidBattlePost(battle, request.getPostId())) {
             throw new GeneralException(ErrorStatus.POST_NOT_BATTLE);
         }
 
@@ -220,5 +220,9 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         if (battle.getPost2() == null) {
             throw new GeneralException(ErrorStatus.POST_IS_CHALLENGE);
         }
+    }
+
+    private boolean isInvalidBattlePost(Battle battle, Long postId) {
+        return !battle.getPost1().getId().equals(postId) && !battle.getPost2().getId().equals(postId);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -149,7 +149,6 @@ public class BattleCommandServiceImpl implements BattleCommandService {
             Slice<Battle> battleList = battleRepository.findByBattleStatusAndDeadlineIsNotNullAndDeadlineBefore(
                     BattleStatus.ACTIVE, LocalDateTime.now(), pageable
             );
-
             List<Battle> updateBattleList = battleList.getContent();
             updateBattleList.forEach(Battle::completeBattle);
 
@@ -212,7 +211,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
             throw new GeneralException(ErrorStatus.VOTE_ALREADY_EXIST);
         }
 
-        // 마감 기한 후 투표 방dho 지
+        // 마감 기한 후 투표 방지
         if (battle.availableVote()) {
             throw new GeneralException(ErrorStatus.VOTE_EXPIRED);
         }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -2,10 +2,7 @@ package UMC_7th.Closit.domain.battle.service.BattleService;
 
 import UMC_7th.Closit.domain.battle.converter.BattleConverter;
 import UMC_7th.Closit.domain.battle.dto.BattleDTO.BattleRequestDTO;
-import UMC_7th.Closit.domain.battle.entity.Battle;
-import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
-import UMC_7th.Closit.domain.battle.entity.Status;
-import UMC_7th.Closit.domain.battle.entity.Vote;
+import UMC_7th.Closit.domain.battle.entity.*;
 import UMC_7th.Closit.domain.battle.repository.BattleRepository;
 import UMC_7th.Closit.domain.battle.repository.ChallengeBattleRepository;
 import UMC_7th.Closit.domain.battle.repository.VoteRepository;
@@ -74,13 +71,13 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         ChallengeBattle challengeBattle = challengeBattleRepository.findById(request.getChallengeBattleId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CHALLENGE_BATTLE_NOT_FOUND));
 
-        challengeBattleRepository.updateBattleStatus(battle, challengeBattle.getId());
+        challengeBattleRepository.updateChallengeStatus(battle, challengeBattle.getId());
 
         // Post1 게시글 작성자만 수락 가능
         if (!battle.getPost1().getUser().getId().equals(userId)) {
             throw new GeneralException(ErrorStatus.BATTLE_UNAUTHORIZED_ACCESS);
         }
-        battle.acceptChallenge(challengeBattle.getPost(), Status.ACTIVE, LocalDate.now().plusDays(3));
+        battle.acceptChallenge(challengeBattle.getPost(), LocalDate.now().plusDays(3));
 
         return battleRepository.save(battle);
     }
@@ -194,8 +191,8 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         }
 
         // Status = INACTIVE일 경우에만 배틀 신청 가능
-        if (battle.getStatus().equals(Status.INACTIVE)) {
-            battle.challengeBattle(Status.PENDING);
+        if (battle.getBattleStatus().equals(BattleStatus.INACTIVE)) {
+            battle.challengeBattle();
         }
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -81,7 +81,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         if (!battle.getPost1().getUser().getId().equals(userId)) {
             throw new GeneralException(ErrorStatus.BATTLE_UNAUTHORIZED_ACCESS);
         }
-        battle.acceptChallenge(challengeBattle.getPost(), LocalDateTime.now().minusHours(72));
+        battle.acceptChallenge(challengeBattle.getPost(), LocalDateTime.now().plusHours(72));
 
         return battleRepository.save(battle);
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -83,7 +83,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
     }
 
     @Override
-    public Battle rejectChallenge (Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request) { // 배틀 신청
+    public Battle rejectChallenge (Long userId, Long battleId, BattleRequestDTO.ChallengeDecisionDTO request) { // 배틀 거절
         Battle battle = battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
@@ -1,13 +1,12 @@
 package UMC_7th.Closit.domain.battle.service.BattleService;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
+import UMC_7th.Closit.domain.battle.entity.BattleSorting;
 import UMC_7th.Closit.domain.battle.entity.BattleStatus;
 import org.springframework.data.domain.Slice;
 
-import java.util.Optional;
-
 public interface BattleQueryService {
 
-    Slice<Battle> getBattleList (Integer page, BattleStatus battleStatus); // 배틀 게시글 목록 조회
-    Slice<Battle> getChallengeBattleList (Integer page); // 배틀 챌린지 게시글 목록 조회
+    Slice<Battle> getBattleList(Integer page, BattleSorting battleSorting, BattleStatus battleStatus); // 배틀 게시글 목록 조회
+    Slice<Battle> getChallengeBattleList (Integer page); // 배틀 챌린지 게시글 목록 조회 - 최신순
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
@@ -1,12 +1,13 @@
 package UMC_7th.Closit.domain.battle.service.BattleService;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
+import UMC_7th.Closit.domain.battle.entity.BattleStatus;
 import org.springframework.data.domain.Slice;
 
 import java.util.Optional;
 
 public interface BattleQueryService {
 
-    Slice<Battle> getBattleList (Integer page); // 배틀 게시글 목록 조회
+    Slice<Battle> getBattleList (Integer page, BattleStatus battleStatus); // 배틀 게시글 목록 조회
     Slice<Battle> getChallengeBattleList (Integer page); // 배틀 챌린지 게시글 목록 조회
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryService.java
@@ -8,5 +8,6 @@ import org.springframework.data.domain.Slice;
 public interface BattleQueryService {
 
     Slice<Battle> getBattleList(Integer page, BattleSorting battleSorting, BattleStatus battleStatus); // 배틀 게시글 목록 조회
-    Slice<Battle> getChallengeBattleList (Integer page); // 배틀 챌린지 게시글 목록 조회 - 최신순
+    Slice<Battle> getChallengeBattleList(Integer page); // 배틀 챌린지 게시글 목록 조회 - 최신순
+    Slice<Battle> getMyVotedBattleList(Integer page); // 내가 투표한 게시글 - 최신순
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -62,4 +62,13 @@ public class BattleQueryServiceImpl implements BattleQueryService {
 
         return challengeBattleList;
     }
+
+    @Override
+    public Slice<Battle> getMyVotedBattleList(Integer page) { // 내가 투표한 게시글 - 최신순
+        User user = securityUtil.getCurrentUser();
+
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        return battleRepository.findVotedBattlesByUserAndPost2IsNotNull(user, pageable);
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package UMC_7th.Closit.domain.battle.service.BattleService;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
+import UMC_7th.Closit.domain.battle.entity.BattleSorting;
 import UMC_7th.Closit.domain.battle.entity.BattleStatus;
 import UMC_7th.Closit.domain.battle.repository.BattleRepository;
 import UMC_7th.Closit.domain.battle.repository.VoteRepository;
@@ -24,11 +25,11 @@ public class BattleQueryServiceImpl implements BattleQueryService {
     private final SecurityUtil securityUtil;
 
     @Override
-    public Slice<Battle> getBattleList(Integer page, BattleStatus battleStatus) { // 배틀 게시글 목록 조회 - 최신순
+    public Slice<Battle> getBattleList(Integer page, BattleSorting battleSorting, BattleStatus battleStatus) { // 배틀 게시글 목록 조회
         User user = securityUtil.getCurrentUser();
         Long userId = user.getId();
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, 10, battleSorting.getSort());
 
         // secondPostId가 not null 기준으로 조회
         Slice<Battle> battleList = battleRepository.findByPost2IsNotNullAndBattleStatus(pageable, battleStatus);

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -57,10 +57,7 @@ public class BattleQueryServiceImpl implements BattleQueryService {
     public Slice<Battle> getChallengeBattleList(Integer page) { // 배틀 챌린지 게시글 목록 조회 - 최신순
         Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        // secondPostId가 null 인 것을 기준으로 조회
-        Slice<Battle> challengeBattleList = battleRepository.findByPost2IsNull(pageable);
-
-        return challengeBattleList;
+        return battleRepository.findByPost2IsNull(pageable);
     }
 
     @Override

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,7 +24,7 @@ public class BattleQueryServiceImpl implements BattleQueryService {
 
     @Override
     public Slice<Battle> getBattleList(Integer page) { // 배틀 게시글 목록 조회
-        Pageable pageable = PageRequest.of(page, 10);
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 
         // secondPostId가 not null 인 것을 기준으로 조회
         Slice<Battle> battleList = battleRepository.findByPost2IsNotNull(pageable);

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -53,8 +53,8 @@ public class BattleQueryServiceImpl implements BattleQueryService {
     }
 
     @Override
-    public Slice<Battle> getChallengeBattleList(Integer page) { // 배틀 챌린지 게시글 목록 조회
-        Pageable pageable = PageRequest.of(page, 10);
+    public Slice<Battle> getChallengeBattleList(Integer page) { // 배틀 챌린지 게시글 목록 조회 - 최신순
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
 
         // secondPostId가 null 인 것을 기준으로 조회
         Slice<Battle> challengeBattleList = battleRepository.findByPost2IsNull(pageable);

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/PostRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/PostRequestDTO.java
@@ -20,7 +20,7 @@ public class PostRequestDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public class HashtagDTO {
+    public static class HashtagDTO {
         @Size(max = 20, message = "해시태그는 20자 이내여야 합니다.")
         private String content;
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #213 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 챌린지 게시글 최신순 정렬
- 진행 중 배틀 최신순, 인기순 정렬
- 진행 완료 배틀 최신순, 인기순 정렬
- 배틀 종료 후, 상태 COMPLETED로 바뀌게 스케줄러 설정
- 내가 투표한 게시글 목록 조회 API


## 📸 스크린샷
- 챌린지 게시글 최신순 정렬
![스크린샷 2025-04-17 142324](https://github.com/user-attachments/assets/7c199c4d-032b-41d8-9233-b9ed49bfbdd9)

- 진행 중 배틀 최신순, 인기순 정렬
![스크린샷 2025-04-17 142420](https://github.com/user-attachments/assets/6d7c6a95-83bd-4a81-9a55-1266f337b3a7)
![스크린샷 2025-04-17 142628](https://github.com/user-attachments/assets/10c7c548-9e04-4b87-86b6-2fd4e31e24f0)

- 진행 완료 배틀 최신순, 인기순 정렬
![스크린샷 2025-04-17 142507](https://github.com/user-attachments/assets/a93beb6f-9231-42af-822e-9c4ec8274aa0)

- 내가 투표한 게시글 목록 조회 API
![image](https://github.com/user-attachments/assets/d61b3329-2bb3-43a3-ad1c-388ba7811f39)

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 조회수 증가 구현하긴 햇는데 배틀 상세보기 생기는 거 결정된 후에 추가적으로 더 할게요
- 그리고 혹시 모든 controller에 tag 붙여도 될까요?.? (사유: 붙이면 알아보기 편함)