### PR TITLE
feat: 사용자 차단 목록 조회

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -99,6 +99,14 @@ public class UserController {
         return ApiResponse.onSuccess("User unblocked successfully");
     }
 
+    @Operation(summary = "사용자 차단 목록 조회", description = "특정 사용자의 차단 목록을 조회합니다.")
+    @GetMapping("/block")
+    public ApiResponse<UserResponseDTO.UserBlockListDTO> getBlockedUserList() {
+        // 한번에 10명씩 조회
+        Slice<User> blockedUserSlice = userQueryService.getBlockedUserList(PageRequest.of(0, 10));
+        return ApiResponse.onSuccess(UserConverter.toUserBlockListDTO(blockedUserSlice));
+    }
+
     @Operation(summary = "사용자의 팔로워 목록 조회", description = "특정 사용자의 팔로워 목록을 조회합니다.")
     @CheckBlocked(targetIdParam = "closit_id")
     @GetMapping("/{closit_id}/followers")

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -112,7 +112,7 @@ public class UserConverter {
 
     public static UserResponseDTO.UserBlockListDTO toUserBlockListDTO(Slice<User> blockedUserSlice) {
         List<UserResponseDTO.UserBlockDTO> blockedUserList =
-                blockedUserSlice.getContent().stream()      // ← here
+                blockedUserSlice.getContent().stream()
                         .map(user -> UserResponseDTO.UserBlockDTO.builder()
                                 .clositId(user.getClositId())
                                 .name(user.getName())

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -110,4 +110,22 @@ public class UserConverter {
                 .build();
     }
 
+    public static UserResponseDTO.UserBlockListDTO toUserBlockListDTO(Slice<User> blockedUserSlice) {
+        List<UserResponseDTO.UserBlockDTO> blockedUserList =
+                blockedUserSlice.getContent().stream()      // ← here
+                        .map(user -> UserResponseDTO.UserBlockDTO.builder()
+                                .clositId(user.getClositId())
+                                .name(user.getName())
+                                .profileImage(user.getProfileImage())
+                                .build())
+                        .collect(Collectors.toList());
+
+        return UserResponseDTO.UserBlockListDTO.builder()
+                .blockedUsers(blockedUserList)
+                .hasNext(blockedUserSlice.hasNext())
+                .pageNumber(blockedUserSlice.getNumber())
+                .size(blockedUserSlice.getSize())
+                .build();
+    }
+
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
@@ -164,4 +164,27 @@ public class UserResponseDTO {
         private String blockerClositId;
         private String blockedClositId;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserBlockListDTO {
+        private List<UserBlockDTO> blockedUsers;
+        private boolean hasNext;
+        private int pageNumber; // 페이지 번호
+        private int size; // 페이지 당 조회 개수
+
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserBlockDTO {
+        private String clositId;
+        private String name;
+        private String profileImage;
+    }
+
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/repository/UserBlockRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/UserBlockRepository.java
@@ -2,7 +2,11 @@ package UMC_7th.Closit.domain.user.repository;
 
 import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.entity.UserBlock;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +14,10 @@ public interface UserBlockRepository extends JpaRepository<UserBlock, Long> {
     boolean existsByBlockerAndBlocked(User blocker, User blocked);
 
     Optional<UserBlock> findByBlockerAndBlocked (User blocker, User blocked);
+
+    Slice<User> findAllByBlocker(User blocker);
+
+    @Query("SELECT ub.blocked FROM UserBlock ub WHERE ub.blocker = :blocker")
+    Slice<User> findBlockedUsersByBlocker(@Param("blocker") User blocker, Pageable pageable);
+
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
@@ -22,5 +22,5 @@ public interface UserQueryService {
 
     Slice<Post> getRecentPostList(String clositId, Integer page); // 특정 사용자의 최근 게시글 조회
 
-    Slice<User> getBlockedUserList(PageRequest pageable);
+    Slice<User> getBlockedUserList(Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
@@ -4,6 +4,7 @@ import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
 import UMC_7th.Closit.domain.user.entity.User;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
@@ -20,4 +21,6 @@ public interface UserQueryService {
     boolean isMissionDone();
 
     Slice<Post> getRecentPostList(String clositId, Integer page); // 특정 사용자의 최근 게시글 조회
+
+    Slice<User> getBlockedUserList(PageRequest pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -9,6 +9,7 @@ import UMC_7th.Closit.domain.post.repository.PostRepository;
 import UMC_7th.Closit.domain.user.converter.UserConverter;
 import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
 import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.UserBlockRepository;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
@@ -32,6 +33,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final FollowRepository followRepository;
     private final PostRepository postRepository;
     private final SecurityUtil securityUtil;
+    private final UserBlockRepository userBlockRepository;
 
     @Override
     public Slice<Highlight> getHighlightList(String clositId, Pageable pageable) {
@@ -91,5 +93,11 @@ public class UserQueryServiceImpl implements UserQueryService {
         Slice<Post> recentPostList = postRepository.findRecentPostList(clositId, week, pageable);
 
         return recentPostList;
+    }
+
+    @Override
+    public Slice<User> getBlockedUserList(PageRequest pageable) {
+        User currentUser = securityUtil.getCurrentUser();
+        return userBlockRepository.findBlockedUsersByBlocker(currentUser, pageable);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -96,7 +96,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
-    public Slice<User> getBlockedUserList(PageRequest pageable) {
+    public Slice<User> getBlockedUserList(Pageable pageable) {
         User currentUser = securityUtil.getCurrentUser();
         return userBlockRepository.findBlockedUsersByBlocker(currentUser, pageable);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #221 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사용자 차단 목록 조회 기능 구현
- `UserBlockListDTO` : 사용자 차단 목록 및, 페이징 관련 정보 포함
- `UserBlockDTO` : 사용자 전체 정보는 필요 없기 때문에 closit id와 name 정보만 담은 객체
- `userBlockRepository` : `findBlockedUsersByBlocker` 추가
    - `@Query("SELECT ub.blocked FROM UserBlock ub WHERE ub.blocker = :blocker")` 를 사용해 UserBlock 객체를 생성하지 않고 곧바로 User 객체 리스트를 반환할 수 있다. 이를 통해 DB 접근 및 객체 생성으로 인한 불필요한 메모리 사용을 줄여 성능을 향상 시킬 수 있다.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/ee42a704-da93-49e3-b873-e0f8bfaf304b)



## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
