### PR TITLE
feat: 사용자 신고 기능 추가

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/report/entity/controller/ReportController.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/controller/ReportController.java
@@ -1,0 +1,27 @@
+package UMC_7th.Closit.domain.report.entity.controller;
+
+import UMC_7th.Closit.domain.report.entity.dto.ReportRequestDTO;
+import UMC_7th.Closit.domain.report.entity.service.ReportService;
+import UMC_7th.Closit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Slf4j
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "사용자 신고", description = "특정 사용자를 신고합니다.")
+    @PostMapping("/report")
+    public ApiResponse<String> reportUser(ReportRequestDTO reportRequestDTO) {
+        reportService.reportUser(reportRequestDTO);
+        return ApiResponse.onSuccess("신고가 완료되었습니다.");
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/report/entity/dto/ReportRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/dto/ReportRequestDTO.java
@@ -1,0 +1,31 @@
+package UMC_7th.Closit.domain.report.entity.dto;
+
+import UMC_7th.Closit.domain.report.entity.Description;
+import UMC_7th.Closit.domain.report.entity.Type;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportRequestDTO {
+    @NotNull(message = "senderId는 필수값입니다.")
+    private Long senderId;
+
+    @NotNull(message = "receiverId는 필수값입니다.")
+    private Long receiverId;
+
+    @NotNull(message = "type은 필수값입니다.")
+    private Type type;
+
+    @NotNull(message = "description은 필수값입니다.")
+    private Description description;
+
+    @Size(max = 500, message = "otherReason은 최대 500자까지 입력 가능합니다.")
+    private String otherReason; // 기타 사유
+}

--- a/src/main/java/UMC_7th/Closit/domain/report/entity/dto/ReportRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/dto/ReportRequestDTO.java
@@ -14,11 +14,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReportRequestDTO {
-    @NotNull(message = "senderId는 필수값입니다.")
-    private Long senderId;
-
     @NotNull(message = "receiverId는 필수값입니다.")
-    private Long receiverId;
+    private String receiverClositId;
 
     @NotNull(message = "type은 필수값입니다.")
     private Type type;

--- a/src/main/java/UMC_7th/Closit/domain/report/entity/dto/ReportRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/dto/ReportRequestDTO.java
@@ -4,14 +4,10 @@ import UMC_7th.Closit.domain.report.entity.Description;
 import UMC_7th.Closit.domain.report.entity.Type;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Builder
 @Getter
-@NoArgsConstructor
 @AllArgsConstructor
 public class ReportRequestDTO {
     @NotNull(message = "receiverId는 필수값입니다.")

--- a/src/main/java/UMC_7th/Closit/domain/report/entity/repository/ReportRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/repository/ReportRepository.java
@@ -1,0 +1,7 @@
+package UMC_7th.Closit.domain.report.entity.repository;
+
+import UMC_7th.Closit.domain.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/UMC_7th/Closit/domain/report/entity/service/ReportService.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/service/ReportService.java
@@ -1,0 +1,51 @@
+package UMC_7th.Closit.domain.report.entity.service;
+
+import UMC_7th.Closit.domain.report.entity.Description;
+import UMC_7th.Closit.domain.report.entity.Report;
+import UMC_7th.Closit.domain.report.entity.dto.ReportRequestDTO;
+import UMC_7th.Closit.domain.report.entity.repository.ReportRepository;
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.UserRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final UserRepository userRepository;
+    private final ReportRepository reportRepository;
+
+    // 신고 처리 로직을 구현합니다.
+    // 예를 들어, 신고 내용을 데이터베이스에 저장하거나, 신고된 사용자의 상태를 업데이트하는 등의 작업을 수행할 수 있습니다.
+    // 이 부분은 비즈니스 로직에 따라 다르게 구현될 수 있습니다.
+
+    // 예시로, 신고 내용을 데이터베이스에 저장하는 메서드를 작성할 수 있습니다.
+    public void reportUser(ReportRequestDTO reportRequestDTO) {
+
+        User sender = userRepository.findById(reportRequestDTO.getSenderId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+        User receiver = userRepository.findById(reportRequestDTO.getReceiverId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // otherReason : Description.OTHER 일 때만 사용
+        String otherReason = reportRequestDTO.getDescription() == Description.OTHER
+                ? reportRequestDTO.getOtherReason()
+                : null;
+
+        Report report = Report.builder()
+                .sender(sender)
+                .receiver(receiver)
+                .type(reportRequestDTO.getType())
+                .description(reportRequestDTO.getDescription())
+                .otherReason(otherReason)
+                .build();
+
+        reportRepository.save(report);
+
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/report/entity/service/ReportService.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/service/ReportService.java
@@ -8,28 +8,26 @@ import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
+import UMC_7th.Closit.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ReportService {
 
     private final UserRepository userRepository;
     private final ReportRepository reportRepository;
+    private final SecurityUtil securityUtil;
 
-    // 신고 처리 로직을 구현합니다.
-    // 예를 들어, 신고 내용을 데이터베이스에 저장하거나, 신고된 사용자의 상태를 업데이트하는 등의 작업을 수행할 수 있습니다.
-    // 이 부분은 비즈니스 로직에 따라 다르게 구현될 수 있습니다.
-
-    // 예시로, 신고 내용을 데이터베이스에 저장하는 메서드를 작성할 수 있습니다.
     public void reportUser(ReportRequestDTO reportRequestDTO) {
 
-        User sender = userRepository.findById(reportRequestDTO.getSenderId())
-                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
-        User receiver = userRepository.findById(reportRequestDTO.getReceiverId())
+        User sender = securityUtil.getCurrentUser();
+        User receiver = userRepository.findByClositId(reportRequestDTO.getReceiverClositId())
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         // otherReason : Description.OTHER 일 때만 사용

--- a/src/main/java/UMC_7th/Closit/domain/report/entity/service/ReportService.java
+++ b/src/main/java/UMC_7th/Closit/domain/report/entity/service/ReportService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 @Slf4j
 public class ReportService {
 
@@ -44,6 +44,5 @@ public class ReportService {
                 .build();
 
         reportRepository.save(report);
-
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -165,4 +165,6 @@ public class UserController {
 
         return ApiResponse.onSuccess(UserConverter.userRecentPostListDTO(recentPostList));
     }
+
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #223 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사용자 신고 기능 추가
- sender Id는 현재 로그인한 사용자 기준으로
- otherReason 필드는 `Description.OTHER` 타입일 때만 사용하도록 함. -> 사용자가 OTHER 선택 안할 경우 null로 저장되도록 했음.
    - 프론트 파트에서 OTHER 선택할 때만 otherReason 적을 수 있도록 처리 필요
- Setter 없이 `@NoArgsConstructor` annotation 사용하면 
    - Jackson(ObjectMapper)가 `@NoArgsConstructor`로 기본 생성자로 객체를 생성하고 Setter로 필드에 값을 주입하는 동작을 하지 못해 클라이언트 요청 값이 들어가지 않아 null 값이 됨.
    - `@NoArgsConstructor` 사용하면 -> Setter 사용하던지, `@AllArgsConstructor` + `@Getter` 사용해야 한다.   


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/5d0fb5c3-a583-4448-aed8-8cf04dad573b)
![image](https://github.com/user-attachments/assets/6a71e835-9018-4f15-ba62-bcc5c0114358)


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- otherReason을 꼭 Description.OTHER를 선택하지 않아도 작성할 수 있도록 하는 것이 적절한지, 지금처럼 선택했을 때만 가능하도록 하는 것이 적절한지에 대해 의견 남겨주세요