### PR TITLE
feat: 사용자 탈퇴 및 7일 유예 기간 적용

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -35,13 +35,6 @@ public class UserController {
     @Value("${cloud.aws.s3.path.profileImage}")
     private String profileImagePath;
 
-    @Operation(summary = "사용자 삭제", description = "특정 사용자를 삭제합니다.")
-    @DeleteMapping()
-    public ApiResponse<String> deleteUser() {
-        userCommandService.deleteUser();
-        return ApiResponse.onSuccess("Deletion successful");
-    }
-
     @Operation(summary = "사용자 정보 수정", description = "사용자 정보를 수정합니다.")
     @PatchMapping()
     public ApiResponse<UserResponseDTO.UserInfoDTO> updateUserInfo(@Valid @RequestBody UserRequestDTO.UpdateUserDTO updateUserDTO) {

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -182,5 +182,18 @@ public class UserController {
         return ApiResponse.onSuccess(UserConverter.userRecentPostListDTO(recentPostList));
     }
 
+    @Operation(summary = "사용자 탈퇴 취소", description = "탈퇴 유예 기간 내 탈퇴를 취소(계정 복구)합니다.")
+    @PostMapping("/withdrawal/cancel")
+    public ApiResponse<String> cancelWithdrawal() {
+        userCommandService.cancelWithdrawal();
+        return ApiResponse.onSuccess("탈퇴가 취소되어 계정이 복구되었습니다.");
+    }
+
+    @Operation(summary = "사용자 탈퇴 요청", description = "사용자가 탈퇴를 요청하면 7일 유예 상태로 변경됩니다.")
+    @PostMapping("/withdrawal")
+    public ApiResponse<String> requestWithdrawal() {
+        userCommandService.deleteUser();
+        return ApiResponse.onSuccess("탈퇴 요청이 정상적으로 처리되었습니다. 7일 이내에 취소하지 않으면 계정이 완전히 삭제됩니다.");
+    }
 
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -4,7 +4,6 @@ import UMC_7th.Closit.domain.battle.entity.BattleComment;
 import UMC_7th.Closit.domain.battle.entity.BattleLike;
 import UMC_7th.Closit.domain.battle.entity.Vote;
 import UMC_7th.Closit.domain.follow.entity.Follow;
-import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.notification.entity.Notification;
 import UMC_7th.Closit.domain.post.entity.Bookmark;
 import UMC_7th.Closit.domain.post.entity.Comment;
@@ -17,6 +16,7 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,6 +60,12 @@ public class User extends BaseEntity {
     // The count of report, default value is 0
     @Column(nullable = false)
     private int countReport;
+
+    @Column(name = "withdrawal_requested_at")
+    private LocalDateTime withdrawalRequestedAt;
+
+    @Column(name = "is_withdrawn", nullable = false)
+    private Boolean isWithdrawn = false;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
@@ -124,12 +130,19 @@ public class User extends BaseEntity {
         this.countReport++;
     }
 
-
     public void updatePassword(String encode) {
         this.password = encode;
     }
 
     public void setBirth(@PastOrPresent(message = "생년월일은 과거나 현재 날짜여야 합니다.") LocalDate birth) {
         this.birth = birth;
+    }
+
+    public void setWithdrawalRequestedAt(LocalDateTime withdrawalRequestedAt) {
+        this.withdrawalRequestedAt = withdrawalRequestedAt;
+    }
+
+    public void setWithdrawn(Boolean withdrawn) {
+        isWithdrawn = withdrawn;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/repository/UserRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/UserRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -28,4 +30,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("UPDATE User u SET u.countReport = u.countReport + 1 WHERE u.id = :id")
     void incrementReportCount(@Param("id") Long id);
+
+    List<User> findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(LocalDateTime dateTime);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
@@ -25,5 +25,5 @@ public interface UserCommandService {
 
     void unblockUser (UserRequestDTO.BlockUserDTO blockUserDTO);
 
-    void cancelWithdrawl();
+    void cancelWithdrawal();
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandService.java
@@ -24,4 +24,6 @@ public interface UserCommandService {
     boolean isBlockedBy(String targetClositId, String clositId);
 
     void unblockUser (UserRequestDTO.BlockUserDTO blockUserDTO);
+
+    void cancelWithdrawl();
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -12,6 +12,7 @@ import UMC_7th.Closit.domain.user.entity.Block;
 import UMC_7th.Closit.domain.user.repository.BlockRepository;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
 import UMC_7th.Closit.global.s3.S3Service;
 import UMC_7th.Closit.security.SecurityUtil;
@@ -231,10 +232,10 @@ public class UserCommandServiceImpl implements UserCommandService {
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         if (persistentUser.getWithdrawalRequestedAt().plusDays(7).isBefore(java.time.LocalDateTime.now())) {
-                throw new UserHandler(ErrorStatus.WITHDRAWAL_PERIOD_EXPIRED);
+            throw new UserHandler(ErrorStatus.WITHDRAWAL_PERIOD_EXPIRED);
         }
-        // 즉시 삭제 대신 탈퇴 유예 상태로 변경
-        persistentUser.setWithdrawn(true);
+
+        persistentUser.setWithdrawn(false);
         persistentUser.setWithdrawalRequestedAt(null);
         userRepository.save(persistentUser);
     }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -221,4 +221,17 @@ public class UserCommandServiceImpl implements UserCommandService {
 
         blockRepository.delete(userBlock);
     }
+
+    @Override
+    public void cancelWithdrawl () {
+        User currentUser = securityUtil.getCurrentUser();
+
+        User persistentUser = userRepository.findById(currentUser.getId())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        // 즉시 삭제 대신 탈퇴 유예 상태로 변경
+        persistentUser.setWithdrawn(true);
+        persistentUser.setWithdrawalRequestedAt(java.time.LocalDateTime.now());
+        userRepository.save(persistentUser);
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
@@ -1,0 +1,31 @@
+package UMC_7th.Closit.domain.user.service;
+
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserWithdrawalScheduler {
+    private final UserRepository userRepository;
+
+    // 매일 새벽 3시에 실행 (cron: 초 분 시 일 월 요일)
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void deleteExpiredWithdrawnUsers() {
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        List<User> expiredUsers = userRepository.findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(sevenDaysAgo);
+        if (!expiredUsers.isEmpty()) {
+            log.info("[UserWithdrawalScheduler] {}명의 탈퇴 유예 만료 계정 삭제", expiredUsers.size());
+            userRepository.deleteAll(expiredUsers);
+        }
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
@@ -24,6 +24,7 @@ public class UserWithdrawalScheduler {
         LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
         List<User> expiredUsers = userRepository.findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(sevenDaysAgo);
         if (!expiredUsers.isEmpty()) {
+            // 확인용 로그
             log.info("[UserWithdrawalScheduler] {}명의 탈퇴 유예 만료 계정 삭제", expiredUsers.size());
             userRepository.deleteAll(expiredUsers);
         }

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -32,7 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_ALREADY_BLOCKED(HttpStatus.CONFLICT, "USER4010", "이미 차단한 사용자입니다."), // 이미 차단한 사용자
     PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "USER4010", "프로필 이미지가 비어 있습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4011", "이메일 인증이 완료되지 않았습니다."),
-
+    WITHDRAWAL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "USER4012", "탈퇴 유예 기간이 만료되었습니다."), // 탈퇴 유예 기간 만료
     // 토큰 관련 에러
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4002", "유효하지 않은 토큰입니다."),

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/exception/GeneralException.java
@@ -4,12 +4,18 @@ import UMC_7th.Closit.global.apiPayload.code.BaseErrorCode;
 import UMC_7th.Closit.global.apiPayload.code.ErrorReasonDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class GeneralException extends RuntimeException {
 
     private BaseErrorCode code;
+
+    public GeneralException(BaseErrorCode code) {
+        super(code.getReason().getMessage());
+        this.code = code;
+    }
 
     public ErrorReasonDTO getErrorReason() {
         return this.code.getReason();

--- a/src/test/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImplTest.java
+++ b/src/test/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImplTest.java
@@ -1,0 +1,85 @@
+package UMC_7th.Closit.domain.user.service;
+
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.UserRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
+import UMC_7th.Closit.security.SecurityUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+class UserCommandServiceImplTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private SecurityUtil securityUtil;
+    @InjectMocks
+    private UserCommandServiceImpl userCommandService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        user = User.builder()
+                .id(1L)
+                .clositId("testuser")
+                .name("테스트")
+                .email("test@test.com")
+                .password("pw")
+                .isWithdrawn(false)
+                .build();
+    }
+
+    @Test
+    @DisplayName("탈퇴 요청 시 isWithdrawn, withdrawalRequestedAt -> true, 현재 시간")
+    void deleteUser_setsWithdrawnAndDate() {
+        when(securityUtil.getCurrentUser()).thenReturn(user);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+
+        userCommandService.deleteUser();
+
+        assertThat(user.getIsWithdrawn()).isTrue();
+        assertThat(user.getWithdrawalRequestedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("탈퇴 취소 시 isWithdrawn=false, withdrawalRequestedAt=null로 복구.")
+    void cancelWithdrawal_success() {
+        user.setWithdrawn(true);
+        user.setWithdrawalRequestedAt(LocalDateTime.now());
+        when(securityUtil.getCurrentUser()).thenReturn(user);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+
+        userCommandService.cancelWithdrawal();
+
+        assertThat(user.getIsWithdrawn()).isFalse();
+        assertThat(user.getWithdrawalRequestedAt()).isNull();
+    }
+
+    @Test
+    // 새벽 3시마다 scheduler 실행되는데, 3시 이전에 탈퇴 요청 시 이미 7일이 지났을 경우 탈퇴 취소 요청 시
+    @DisplayName("탈퇴 취소 시 7일이 지나면 예외 발생")
+    void cancelWithdrawal_expired() {
+        user.setWithdrawn(true);
+        user.setWithdrawalRequestedAt(LocalDateTime.now().minusDays(8));
+        when(securityUtil.getCurrentUser()).thenReturn(user);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> userCommandService.cancelWithdrawal())
+                .isInstanceOf(UserHandler.class)
+                .hasMessageContaining(ErrorStatus.WITHDRAWAL_PERIOD_EXPIRED.getMessage());
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

#250 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사용자 탈퇴 요청 여부 column 추가(= `isWithdrawn`)
- 사용자 탈퇴 요청 시간 column 추가(= `withdrawalRequestedAt`)
- 매일 새벽 3시마다 탈퇴 요청 후 7일이 지난 사용자를 삭제하는 스케줄러 추가
  - 매일 새벽 3시마다 수행하기 때문에 3시 전에 이미 7일이 지난 사용자가 탈퇴 취소 요청 거부
  - Swagger 테스트가 불가하여 테스트 코드 작성 후 정상 작동 확인
- 기존에 있던 사용자 삭제 컨트롤러 삭제

## 📸 스크린샷
#### 사용자 탈퇴 API 요청 결과
![image](https://github.com/user-attachments/assets/d3755ccf-a947-4e79-a19b-8013bca42605)
#### 탈퇴 요청 후 요청 여부 값 및 요청 시간 값 변경 확인
![image](https://github.com/user-attachments/assets/7bcafb7b-fc49-4ad7-82d6-61b9101066e5)
#### 탈퇴 취소 API 요청 결과
![image](https://github.com/user-attachments/assets/9cdadede-9283-47d6-8c32-c31d208de201)
#### 취소 후 값 변경 확인
![image](https://github.com/user-attachments/assets/102a9b7b-c92f-4430-a0ce-7deeedeb5bb6)



## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
