### PR TITLE
feat: 대댓글 기능 구현

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/CommentController.java
@@ -30,7 +30,12 @@ public class CommentController {
             ### PathVariable
             post_id [게시글 ID] \n
             ### RequestBody
-            content [댓글 내용]
+            - `content` (String): 댓글 내용 (필수)
+            - `parentId` (Long, optional): 대댓글의 경우 부모 댓글 ID를 입력하세요.
+            - `parentId`가 `null`일시 → 일반 댓글(부모 댓글)로 처리됩니다.
+            - `parentId`가 존재할 경우:
+            - 해당 ID는 반드시 같은 게시글의 댓글이어야 합니다.
+            - 부모 댓글의 대댓글까지만 허용되며, 대댓글의 대댓글은 작성할 수 없습니다.
             """)
     public ApiResponse<CommentResponseDTO.CreateCommentResultDTO> createComment(
             @RequestBody @Valid CommentRequestDTO.CreateCommentRequestDTO request,

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/CommentConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/CommentConverter.java
@@ -12,11 +12,12 @@ import java.util.stream.Collectors;
 
 public class CommentConverter {
 
-    public static Comment toComment(User user, Post post, CommentRequestDTO.CreateCommentRequestDTO request) {
+    public static Comment toComment(User user, Post post, CommentRequestDTO.CreateCommentRequestDTO request, Comment parent) {
         return Comment.builder()
                 .user(user)
                 .post(post)
                 .content(request.getContent())
+                .parent(parent)
                 .build();
     }
 
@@ -33,7 +34,11 @@ public class CommentConverter {
                 .commentId(comment.getId())
                 .clositId(comment.getUser().getClositId())
                 .content(comment.getContent())
+                .isParent(comment.isParent())
                 .createdAt(comment.getCreatedAt())
+                .replies(comment.getChildren().stream()
+                        .map(CommentConverter::commentPreviewDTO)
+                        .collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/CommentRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/CommentRequestDTO.java
@@ -9,5 +9,7 @@ public class CommentRequestDTO {
     public static class CreateCommentRequestDTO{
         @NotBlank
         private String content;
+
+        private Long parentId;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/CommentResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/CommentResponseDTO.java
@@ -29,6 +29,8 @@ public class CommentResponseDTO {
         private String clositId;
         private Long commentId;
         private String content;
+        private boolean isParent;
+        private List<CommentPreviewDTO> replies;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Comment.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Comment.java
@@ -5,6 +5,9 @@ import UMC_7th.Closit.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Builder
@@ -28,4 +31,14 @@ public class Comment extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> children = new ArrayList<>();
+
+    public boolean isParent() {
+        return this.parent == null;
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/CommentRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/CommentRepository.java
@@ -3,9 +3,11 @@ package UMC_7th.Closit.domain.post.repository;
 import UMC_7th.Closit.domain.post.entity.Comment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    Slice<Comment> findAllByPostId(Long postId, Pageable pageable);
+    @EntityGraph(attributePaths = {"children", "children.user"})
+    Slice<Comment> findAllByPostIdAndParentIsNull(Long postId, Pageable pageable);
 }
 

--- a/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
@@ -41,6 +41,9 @@ public class CommentCommandServiceImpl implements CommentCommandService {
             if (parent.getParent() != null) {
                 throw new GeneralException(ErrorStatus.REPLY_DEPTH_EXCEEDED);
             }
+            if (!parent.getPost().getId().equals(postId)) {
+                throw new GeneralException(ErrorStatus.PARENT_COMMENT_NOT_MATCHED);
+            }
         }
 
         Comment comment = CommentConverter.toComment(user, post, request, parent);

--- a/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/CommentCommandServiceImpl.java
@@ -33,7 +33,17 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
         User user = securityUtil.getCurrentUser();
 
-        Comment comment = CommentConverter.toComment(user, post, request);
+        Comment parent = null;
+
+        if (request.getParentId() != null) {
+            parent = commentRepository.findById(request.getParentId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+            if (parent.getParent() != null) {
+                throw new GeneralException(ErrorStatus.REPLY_DEPTH_EXCEEDED);
+            }
+        }
+
+        Comment comment = CommentConverter.toComment(user, post, request, parent);
 
         // 댓글 알림
         notiCommandService.commentNotification(comment);

--- a/src/main/java/UMC_7th/Closit/domain/post/service/CommentQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/CommentQueryServiceImpl.java
@@ -29,7 +29,7 @@ public class CommentQueryServiceImpl implements CommentQueryService {
 
         Pageable pageable = PageRequest.of(page, 10);
 
-        return commentRepository.findAllByPostId(postId, pageable);
+        return commentRepository.findAllByPostIdAndParentIsNull(postId, pageable);
     }
 }
 

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -72,6 +72,7 @@ public enum ErrorStatus implements BaseErrorCode {
     COMMENT_NOT_FOUND (HttpStatus.NOT_FOUND, "COMMENT4041", "댓글이 존재하지 않습니다."),
     COMMENT_NOT_MINE (HttpStatus.BAD_REQUEST, "COMMENT4001", "해당 댓글은 다른 사용자의 댓글입니다"),
     REPLY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "COMMENT4002", "대댓글은 한 단계까지만 허용됩니다."),
+    PARENT_COMMENT_NOT_MATCHED(HttpStatus.BAD_REQUEST, "COMMENT4003", "부모 댓글이 해당 게시글의 댓글이 아닙니다."),
 
     // 배틀 관련 에러
     BATTLE_NOT_CHALLENGE (HttpStatus.BAD_REQUEST, "BATTLE4001", "동일한 게시글로 배틀을 신청할 수 없습니다."),

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -33,6 +33,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "USER4010", "프로필 이미지가 비어 있습니다."),
     EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "USER4011", "이메일 인증이 완료되지 않았습니다."),
     WITHDRAWAL_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "USER4012", "탈퇴 유예 기간이 만료되었습니다."), // 탈퇴 유예 기간 만료
+
     // 토큰 관련 에러
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4001", "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.BAD_REQUEST, "TOKEN4002", "유효하지 않은 토큰입니다."),
@@ -69,7 +70,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 댓글 관련 에러
     COMMENT_NOT_FOUND (HttpStatus.NOT_FOUND, "COMMENT4041", "댓글이 존재하지 않습니다."),
-    COMMENT_NOT_MINE (HttpStatus.BAD_REQUEST, "COMMENT4002", "해당 댓글은 다른 사용자의 댓글입니다"),
+    COMMENT_NOT_MINE (HttpStatus.BAD_REQUEST, "COMMENT4001", "해당 댓글은 다른 사용자의 댓글입니다"),
+    REPLY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "COMMENT4002", "대댓글은 한 단계까지만 허용됩니다."),
 
     // 배틀 관련 에러
     BATTLE_NOT_CHALLENGE (HttpStatus.BAD_REQUEST, "BATTLE4001", "동일한 게시글로 배틀을 신청할 수 없습니다."),


### PR DESCRIPTION
## 🔗 연관된 이슈

- #257 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 대댓글 기능을 구현했습니다(parentId를 통해 대댓글을 달 수 있도록 하였습니다. 부모 댓글의 대댓글까지만 허용되며, 대댓글의 대댓글은 작성할 수 없습니다.)

## 📸 스크린샷
<img width="1424" alt="스크린샷 2025-06-03 오전 4 05 36" src="https://github.com/user-attachments/assets/1ae235e7-5fc1-45bf-9cdb-b3f2717e5079" />
<img width="1424" alt="스크린샷 2025-06-03 오전 4 05 58" src="https://github.com/user-attachments/assets/52917c25-b605-44f1-b8ce-212e49f2e696" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
레포지토리에서 @EntityGraph라는 어노테이션을 처음 써봐서 이게 맞는지 한 번 봐주세요..