### PR TITLE
feat: 해시태그, 아이템 태그 검색 결과 정렬 기능 구현

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
@@ -1,6 +1,5 @@
 package UMC_7th.Closit.domain.post.controller;
 
-import UMC_7th.Closit.domain.battle.entity.enums.BattleSorting;
 import UMC_7th.Closit.domain.post.converter.PostConverter;
 import UMC_7th.Closit.domain.post.dto.PostRequestDTO;
 import UMC_7th.Closit.domain.post.dto.PostResponseDTO;

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
@@ -144,29 +144,29 @@ public class PostController {
         return ApiResponse.onSuccess(PostConverter.toPostPreviewListDTO(posts));
     }
 
-    @Operation(summary = "아이템 태그 기반 게시글 검색",
-            description = """
-            ## 아이템 태그 기반 게시글 검색
-            특정 아이템 태그가 포함된 게시글 목록을 페이징하여 조회합니다.
-
-            ### Request Parameters
-            - itemtag (선택): 검색할 아이템 태그 (예: 청바지, 후드티 등)
-            - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
-            - size (기본값: 10): 페이지당 항목 수
-            - sorting (필수): 정렬 기준 (LATEST: 최신순, VIEW: 조회수순)
-            """)
-    @GetMapping("/itemtag")
-    public ApiResponse<PostResponseDTO.PostPreviewListDTO> getPostListByItemTag(
-            @RequestParam(name = "itemtag", required = false) String itemTag,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(name ="sorting") PostSorting sorting) {
-
-        Pageable pageable = PageRequest.of(page, size, sorting.getSort());
-        Slice<PostResponseDTO.PostPreviewDTO> posts = postQueryService.getPostListByItemTag(itemTag, pageable);
-
-        return ApiResponse.onSuccess(PostConverter.toPostPreviewListDTO(posts));
-    }
+//    @Operation(summary = "아이템 태그 기반 게시글 검색",
+//            description = """
+//            ## 아이템 태그 기반 게시글 검색
+//            특정 아이템 태그가 포함된 게시글 목록을 페이징하여 조회합니다.
+//
+//            ### Request Parameters
+//            - itemtag (선택): 검색할 아이템 태그 (예: 청바지, 후드티 등)
+//            - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
+//            - size (기본값: 10): 페이지당 항목 수
+//            - sorting (필수): 정렬 기준 (LATEST: 최신순, VIEW: 조회수순)
+//            """)
+//    @GetMapping("/itemtag")
+//    public ApiResponse<PostResponseDTO.PostPreviewListDTO> getPostListByItemTag(
+//            @RequestParam(name = "itemtag", required = false) String itemTag,
+//            @RequestParam(defaultValue = "0") int page,
+//            @RequestParam(defaultValue = "10") int size,
+//            @RequestParam(name ="sorting") PostSorting sorting) {
+//
+//        Pageable pageable = PageRequest.of(page, size, sorting.getSort());
+//        Slice<PostResponseDTO.PostPreviewDTO> posts = postQueryService.getPostListByItemTag(itemTag, pageable);
+//
+//        return ApiResponse.onSuccess(PostConverter.toPostPreviewListDTO(posts));
+//    }
 
     @Operation(summary = "게시글 수정")
     @PutMapping("/{post_id}")

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.domain.post.controller;
 
+import UMC_7th.Closit.domain.battle.entity.enums.BattleSorting;
 import UMC_7th.Closit.domain.post.converter.PostConverter;
 import UMC_7th.Closit.domain.post.dto.PostRequestDTO;
 import UMC_7th.Closit.domain.post.dto.PostResponseDTO;
@@ -120,27 +121,49 @@ public class PostController {
     }
 
 
-    @Operation(summary = "해시태그 기반 게시글 검색")
+    @Operation(summary = "해시태그 기반 게시글 검색",
+            description = """
+            ## 해시태그 기반 게시글 검색
+            특정 해시태그가 포함된 게시글 목록을 페이징하여 조회합니다.
+
+            ### Request Parameters
+            - hashtag (선택): 검색할 해시태그 (예: ootd)
+            - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
+            - size (기본값: 10): 페이지당 항목 수
+            - sorting (필수): 정렬 기준 (LATEST: 최신순, VIEW: 조회수순)
+            """)
     @GetMapping("/hashtag")
     public ApiResponse<PostResponseDTO.PostPreviewListDTO> getPostListByHashtag(
             @RequestParam(name = "hashtag", required = false) String hashtag,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(name ="sorting") PostSorting sorting) {
 
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, sorting.getSort());
         Slice<PostResponseDTO.PostPreviewDTO> posts = postQueryService.getPostListByHashtag(hashtag, pageable);
 
         return ApiResponse.onSuccess(PostConverter.toPostPreviewListDTO(posts));
     }
 
-    @Operation(summary = "아이템 태그 기반 게시글 검색")
+    @Operation(summary = "아이템 태그 기반 게시글 검색",
+            description = """
+            ## 아이템 태그 기반 게시글 검색
+            특정 아이템 태그가 포함된 게시글 목록을 페이징하여 조회합니다.
+
+            ### Request Parameters
+            - itemtag (선택): 검색할 아이템 태그 (예: 청바지, 후드티 등)
+            - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
+            - size (기본값: 10): 페이지당 항목 수
+            - sorting (필수): 정렬 기준 (LATEST: 최신순, VIEW: 조회수순)
+            """)
     @GetMapping("/itemtag")
     public ApiResponse<PostResponseDTO.PostPreviewListDTO> getPostListByItemTag(
             @RequestParam(name = "itemtag", required = false) String itemTag,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(name ="sorting") PostSorting sorting) {
 
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, sorting.getSort());
         Slice<PostResponseDTO.PostPreviewDTO> posts = postQueryService.getPostListByItemTag(itemTag, pageable);
 
         return ApiResponse.onSuccess(PostConverter.toPostPreviewListDTO(posts));

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/PostSorting.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/PostSorting.java
@@ -14,4 +14,3 @@ public enum PostSorting {
         this.sort = sort;
     }
 }
-

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -24,10 +24,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p JOIN p.postHashtagList pht WHERE p.user IN :users AND pht.hashtag.id = :hashtagId ORDER BY p.createdAt DESC")
     Slice<Post> findByUsersAndHashtagId(List<User> users, Long hashtagId, Pageable pageable);
 
-    @Query("SELECT p FROM Post p JOIN p.postHashtagList pht WHERE pht.hashtag.id = :hashtagId ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM Post p JOIN p.postHashtagList pht WHERE pht.hashtag.id = :hashtagId")
     Slice<Post> findByHashtagId(Long hashtagId, Pageable pageable);
 
-    @Query("SELECT p FROM Post p JOIN p.postItemTagList pit WHERE pit.itemTag.id = :itemTagId ORDER BY p.createdAt DESC")
+    @Query("SELECT p FROM Post p JOIN p.postItemTagList pit WHERE pit.itemTag.id = :itemTagId")
     Slice<Post> findByItemTagId(@Param("itemTagId") Long itemTagId, Pageable pageable);
 
     Slice<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -65,6 +65,7 @@ public class User extends BaseEntity {
     private LocalDateTime withdrawalRequestedAt;
 
     @Column(name = "is_withdrawn", nullable = false)
+    @Builder.Default
     private Boolean isWithdrawn = false;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)


### PR DESCRIPTION
## 🔗 연관된 이슈
- #254 

## 📝 작업 내용
- 해시태그 검색 결과 정렬 기능 구현
- 아이템 태그 검색 결과 정렬 기능 구현
(정빈, 나연이가 적어준 코드들 보고 빠르게 했습니다.. 최고💓💓💓)

추가로, User 생성할 때 isWithdrawn의 디폴트 값이 제대로 적용이 안 되어 오류가 발생하길래 디폴트 값이 제대로 적용되도록 수정해주었습니다. 

## 📸 스크린샷
- 해시태그 기반 검색 (최신순)
![image](https://github.com/user-attachments/assets/ea042395-532a-41e5-b2a7-125ae62c0a73)
![image](https://github.com/user-attachments/assets/7413e7a1-1351-49c3-a941-6eda43f72ba4)
![image](https://github.com/user-attachments/assets/b56b8122-4c08-4ffe-9652-561db7b4e8ba)
- 해시태그 기반 검색 (조회순)
![image](https://github.com/user-attachments/assets/142a7232-c7f8-4029-a193-7c992785935a)
![image](https://github.com/user-attachments/assets/71fc56ef-21b3-4c58-baa1-f04d225c8e94)
![image](https://github.com/user-attachments/assets/5bb8e062-20d2-4498-94a6-3a5f3759f5c9)
- 아이템 태그 기반 검색 (최신순)
![image](https://github.com/user-attachments/assets/c81dc2bb-b1dd-47cf-9639-dd9906b14efe)
![image](https://github.com/user-attachments/assets/e80e2ddf-e9e0-4824-bd9b-ba998ff50701)
![image](https://github.com/user-attachments/assets/3b31f3d0-5d9b-4f65-ae95-ca54f823da78)
- 아이템 태그 기반 검색 (조회순)
![image](https://github.com/user-attachments/assets/e08376cf-7ddd-4287-b814-7c129277d571)
![image](https://github.com/user-attachments/assets/8d58f514-20b7-41af-a4da-bd0100632e12)
![image](https://github.com/user-attachments/assets/b229363b-2133-4147-a4dd-de346138147a)


