### PR TITLE
refactor: 배틀 대댓글 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleCommentConverter.java
@@ -38,6 +38,9 @@ public class BattleCommentConverter {
                 .clositId(battleComment.getUser().getClositId())
                 .thumbnail(battleComment.getUser().getProfileImage())
                 .content(battleComment.getContent())
+                .childrenBattleComments(battleComment.getChildrenBattleComments().stream()
+                        .map(BattleCommentConverter::battleCommentPreviewDTO)
+                        .collect(Collectors.toList()))
                 .createdAt(battleComment.getCreatedAt())
                 .build();
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleCmtDTO/BattleCommentResponseDTO.java
@@ -34,6 +34,7 @@ public class BattleCommentResponseDTO {
         private String clositId;
         private String thumbnail;
         private String content;
+        private List<BattleCommentPreviewDTO> childrenBattleComments;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleCommentRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleCommentRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BattleCommentRepository extends JpaRepository<BattleComment, Long> {
-    @EntityGraph(attributePaths = "childrenBattleComments")
+    @EntityGraph(attributePaths = {
+            "childrenBattleComments",
+            "childrenBattleComments.user"
+    })
     Slice<BattleComment> findByBattleIdAndParentBattleCommentIsNullOrderByCreatedAtAsc(Long battleId, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleCommentRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleCommentRepository.java
@@ -3,8 +3,10 @@ package UMC_7th.Closit.domain.battle.repository;
 import UMC_7th.Closit.domain.battle.entity.BattleComment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BattleCommentRepository extends JpaRepository<BattleComment, Long> {
-    Slice<BattleComment> findAllByBattleId(Long battleId, Pageable pageable);
+    @EntityGraph(attributePaths = "childrenBattleComments")
+    Slice<BattleComment> findByBattleIdAndParentBattleCommentIsNullOrderByCreatedAtAsc(Long battleId, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleCmtService/BattleCmtCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleCmtService/BattleCmtCommandServiceImpl.java
@@ -37,8 +37,12 @@ public class BattleCmtCommandServiceImpl implements BattleCmtCommandService {
         if (request.getParentCommentId() != null) {
             parentBattleComment = battleCommentRepository.findById(request.getParentCommentId())
                     .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_COMMENT_NOT_FOUND));
-        }
 
+            // 대댓글의 대댓글을 달려고 할 경우
+            if (parentBattleComment.getParentBattleComment() != null) {
+                throw new GeneralException(ErrorStatus.BATTLE_COMMENT_DEPTH_EXCEEDED);
+            }
+        }
         BattleComment battleComment = BattleCommentConverter.toBattleComment(user, battle, parentBattleComment, request);
 
         return battleCommentRepository.save(battleComment);

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleCmtService/BattleCmtQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleCmtService/BattleCmtQueryServiceImpl.java
@@ -1,6 +1,5 @@
 package UMC_7th.Closit.domain.battle.service.BattleCmtService;
 
-import UMC_7th.Closit.domain.battle.entity.Battle;
 import UMC_7th.Closit.domain.battle.entity.BattleComment;
 import UMC_7th.Closit.domain.battle.repository.BattleCommentRepository;
 import UMC_7th.Closit.domain.battle.repository.BattleRepository;
@@ -8,7 +7,6 @@ import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,15 +20,10 @@ public class BattleCmtQueryServiceImpl implements BattleCmtQueryService {
     private final BattleCommentRepository battleCommentRepository;
 
     @Override
-    @Transactional(readOnly = true)
     public Slice<BattleComment> getBattleCommentList (Long battleId, Integer page) { // 배틀 댓글 조회
         battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 
-        Pageable pageable = PageRequest.of(page, 10);
-
-        Slice<BattleComment> battleCommentList = battleCommentRepository.findAllByBattleId(battleId, pageable);
-
-        return battleCommentList;
+        return battleCommentRepository.findByBattleIdAndParentBattleCommentIsNullOrderByCreatedAtAsc(battleId, PageRequest.of(page, 10));
     }
 }

--- a/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/UMC_7th/Closit/global/apiPayload/code/status/ErrorStatus.java
@@ -96,6 +96,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 배틀 댓글 관련 에러
     BATTLE_COMMENT_NOT_FOUND (HttpStatus.NOT_FOUND, "BATTLECOMMENT4041", "배틀 댓글이 존재하지 않습니다."),
+    BATTLE_COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "BATTLECOMMENT4001", "배틀 대댓글은 한 단계까지만 허용됩니다."),
 
     // 하이라이트 관련 에러
     HIGHLIGHT_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "HIGHLIGHT4001", "이미 존재하는 하이라이트 입니다."),


### PR DESCRIPTION
## 🔗 연관된 이슈

- #269

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 배틀 대댓글 수정

## 📸 스크린샷
- 배틀 댓글 조회
![image](https://github.com/user-attachments/assets/c9c659e3-a11e-4caa-bfb2-543c03b0673f)
- depth = 2를 초과했을 경우, 오류 발생
![스크린샷 2025-06-26 190607](https://github.com/user-attachments/assets/f6aae78c-1599-44d5-8a65-bc702953f5ab)


## 💬 리뷰 요구사항
나연이 코드 참고 했습니당 나연이 짱~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Battle comments now support displaying nested replies, allowing users to view threaded comment discussions.
  * Added a restriction to limit replies to one level deep; further nesting is not allowed, and users will be notified if this limit is exceeded.

* **Bug Fixes**
  * Improved the retrieval and display of battle comments to show only top-level comments with their direct replies in chronological order.

* **Error Handling**
  * Added a specific error message when attempting to reply beyond the allowed depth for battle comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->