### PR TITLE
fix: 사용자 탈퇴 오류 

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -68,6 +68,10 @@ public class Battle extends BaseEntity {
     @Builder.Default
     private List<Vote> voteList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "battle", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<ChallengeBattle> challengeBattleList = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id1")
     private Post post1;

--- a/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
@@ -12,20 +12,21 @@ import java.util.stream.Collectors;
 
 public class NotificationConverter {
 
-    public static Notification toNotification(User user, User sender, NotificationRequestDTO.SendNotiRequestDTO request) { // 알림 전송
+    public static Notification toNotification(User receiver, User sender, NotificationRequestDTO.SendNotiRequestDTO request) { // 알림 전송
         return Notification.builder()
-                .user(user)
-                .sender(sender)
+                .user(receiver)
+                .senderId(sender.getId())
+                .senderImageUrl(sender.getProfileImage())
                 .content(request.getContent())
                 .url(request.getUrl())
                 .type(request.getType())
+                .isRead(false)
                 .build();
     }
 
-    public static NotificationRequestDTO.SendNotiRequestDTO sendNotiRequest(User receiver, User sender, String content, String url, NotificationType notificationType) {
+    public static NotificationRequestDTO.SendNotiRequestDTO sendNotiRequest(User receiver, String content, String url, NotificationType notificationType) {
         return NotificationRequestDTO.SendNotiRequestDTO.builder()
                 .receiverId(receiver.getId())
-                .senderId(sender.getId())
                 .content(content)
                 .url(url)
                 .type(notificationType)
@@ -46,9 +47,8 @@ public class NotificationConverter {
     public static NotificationResponseDTO.NotiPreviewDTO getNotiPreviewDTO(Notification notification) { // 알림 단건 조회
         return NotificationResponseDTO.NotiPreviewDTO.builder()
                 .notificationId(notification.getId())
-                .clositId(notification.getUser().getClositId())
-                .userName(notification.getUser().getName())
-                .imageUrl(notification.getSender().getProfileImage())
+                .userName(notification.getSenderName())
+                .imageUrl(notification.getSenderImageUrl())
                 .content(notification.getContent())
                 .url(notification.getUrl())
                 .type(notification.getType())

--- a/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/converter/NotificationConverter.java
@@ -16,6 +16,7 @@ public class NotificationConverter {
         return Notification.builder()
                 .user(receiver)
                 .senderId(sender.getId())
+                .senderName(sender.getName())
                 .senderImageUrl(sender.getProfileImage())
                 .content(request.getContent())
                 .url(request.getUrl())
@@ -47,7 +48,7 @@ public class NotificationConverter {
     public static NotificationResponseDTO.NotiPreviewDTO getNotiPreviewDTO(Notification notification) { // 알림 단건 조회
         return NotificationResponseDTO.NotiPreviewDTO.builder()
                 .notificationId(notification.getId())
-                .userName(notification.getSenderName())
+                .receiverClositId(notification.getUser().getClositId())
                 .imageUrl(notification.getSenderImageUrl())
                 .content(notification.getContent())
                 .url(notification.getUrl())

--- a/src/main/java/UMC_7th/Closit/domain/notification/dto/NotificationRequestDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/dto/NotificationRequestDTO.java
@@ -10,7 +10,6 @@ public class NotificationRequestDTO {
     @Builder
     public static class SendNotiRequestDTO { // 알림 전송
         private Long receiverId;
-        private Long senderId;
         private String content;
         private String url;
         private NotificationType type;

--- a/src/main/java/UMC_7th/Closit/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/dto/NotificationResponseDTO.java
@@ -32,8 +32,7 @@ public class NotificationResponseDTO {
     @AllArgsConstructor
     public static class NotiPreviewDTO { // 알림 단건 조회
         private Long notificationId;
-        private String clositId;
-        private String userName;
+        private String receiverClositId;
         private String imageUrl;
         private String content;
         private String url;

--- a/src/main/java/UMC_7th/Closit/domain/notification/entity/Notification.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/entity/Notification.java
@@ -30,13 +30,13 @@ public class Notification extends BaseEntity {
     @Column(nullable = false, length = 20)
     private NotificationType type;
 
-    @Column(name = "sender_id", nullable = false)
+    @Column(name = "sender_id")
     private Long senderId;
 
-    @Column(nullable = false)
+    @Column(name = "sender_name")
     private String senderName;
 
-    @Column
+    @Column(name = "sender_image_url")
     private String senderImageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/UMC_7th/Closit/domain/notification/entity/Notification.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/entity/Notification.java
@@ -17,14 +17,6 @@ public class Notification extends BaseEntity {
     @Column(name = "notification_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sender_id", nullable = false)
-    private User sender;
-
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
@@ -37,6 +29,19 @@ public class Notification extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private NotificationType type;
+
+    @Column(name = "sender_id", nullable = false)
+    private Long senderId;
+
+    @Column(nullable = false)
+    private String senderName;
+
+    @Column
+    private String senderImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     public void markAsRead() { // 알림 단건 조회 - 읽음 처리
         isRead = true;

--- a/src/main/java/UMC_7th/Closit/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/repository/NotificationRepository.java
@@ -17,5 +17,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Modifying
     @Query("UPDATE Notification n SET n.isRead = true, n.updatedAt = :updatedAt WHERE n.user.id = :userId AND n.isRead = false")
-    Integer updateReadStatusByUserId (@Param("userId") Long userId, @Param("updatedAt") LocalDateTime updatedAt); // isRead 업데이트
+    void updateReadStatusByUserId (@Param("userId") Long userId, @Param("updatedAt") LocalDateTime updatedAt); // isRead 업데이트
 }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -90,13 +90,13 @@ public class NotiCommandServiceImpl implements NotiCommandService {
 
     @Override
     public Notification sendNotification(NotificationRequestDTO.SendNotiRequestDTO request) { // 알림 전송
-        User user = userRepository.findById(request.getReceiverId())
+        User receiver = userRepository.findById(request.getReceiverId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        User sender = userRepository.findById(request.getSenderId())
+        User sender = userRepository.findById(securityUtil.getCurrentUser().getId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        Notification notification = NotificationConverter.toNotification(user, sender, request);
+        Notification notification = NotificationConverter.toNotification(receiver, sender, request);
 
         // 저장 후 전송
         notificationRepository.save(notification);
@@ -116,13 +116,13 @@ public class NotiCommandServiceImpl implements NotiCommandService {
     @Override
     public void likeNotification(Likes likes) { // 좋아요 알림
         User receiver = likes.getPost().getUser(); // 게시글 작성자
-        User sender = likes.getUser();
-        String content = likes.getUser().getName() + "님이 좋아요를 눌렀습니다.";
+        User sender = securityUtil.getCurrentUser();
+        String content = sender.getName() + "님이 좋아요를 눌렀습니다.";
         String url = URL + "/posts/" + likes.getPost().getId() + "/likes";
 
         // 좋아요를 누른 사용자가 본인이 아닐 경우, 알림 전송
         if (!receiver.getId().equals(likes.getUser().getId())) {
-            NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, sender, content, url, NotificationType.LIKE);
+            NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, url, NotificationType.LIKE);
             sendNotification(request);
         }
     }
@@ -130,13 +130,13 @@ public class NotiCommandServiceImpl implements NotiCommandService {
     @Override
     public void commentNotification(Comment comment) { // 댓글 알림
         User receiver = comment.getPost().getUser(); // 게시글 작성자 ID
-        User sender = comment.getUser();
-        String content = comment.getUser().getName() + "님이 댓글을 작성했습니다.";
+        User sender = securityUtil.getCurrentUser();
+        String content = sender.getName() + "님이 댓글을 작성했습니다.";
         String url = URL + "/posts/" + comment.getPost().getId() + "/comments";
 
         // 댓글을 작성한 사용자가 본인이 아닐 경우, 알림 전송
         if (!receiver.getId().equals(comment.getUser().getId())) {
-            NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, sender, content, url, NotificationType.COMMENT);
+            NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, url, NotificationType.COMMENT);
             sendNotification(request);
         }
     }
@@ -144,11 +144,11 @@ public class NotiCommandServiceImpl implements NotiCommandService {
     @Override
     public void followNotification(Follow follow) { // 팔로우 알림
         User receiver = follow.getReceiver(); // 팔로워 알림 받는 사용자
-        User sender = follow.getSender();
-        String content = follow.getSender().getName() + "님이 회원님을 팔로우하기 시작했습니다.";
+        User sender = securityUtil.getCurrentUser();
+        String content = sender.getName() + "님이 회원님을 팔로우하기 시작했습니다.";
         String url = URL + "/users/" + sender.getClositId();
 
-        NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, sender, content, url, NotificationType.FOLLOW);
+        NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, url, NotificationType.FOLLOW);
 
         sendNotification(request);
     }
@@ -177,11 +177,11 @@ public class NotiCommandServiceImpl implements NotiCommandService {
     @Override
     public void challengeBattleNotification(ChallengeBattle challengeBattle) {
         User receiver = challengeBattle.getBattle().getPost1().getUser();
-        User sender = challengeBattle.getPost().getUser();
-        String content = challengeBattle.getPost().getUser().getName() + "님이 배틀을 신청하셨습니다.";
+        User sender = securityUtil.getCurrentUser();
+        String content = sender.getName() + "님이 배틀을 신청하셨습니다.";
         String url = URL + "/communities/battle/challenge/upload/" + challengeBattle.getBattle().getId();
 
-        NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, sender, content, url, NotificationType.CHALLENGE_BATTLE);
+        NotificationRequestDTO.SendNotiRequestDTO request = NotificationConverter.sendNotiRequest(receiver, content, url, NotificationType.CHALLENGE_BATTLE);
 
         sendNotification(request);
     }

--- a/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/notification/service/NotiCommandServiceImpl.java
@@ -44,7 +44,7 @@ public class NotiCommandServiceImpl implements NotiCommandService {
     private final EmitterRepository emitterRepository;
     private final SecurityUtil securityUtil;
 
-    @Value("${notification.url}")
+    @Value("${server.domain}")
     private String URL;
 
     @Override

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Comment.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Comment.java
@@ -20,11 +20,11 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="post_id", nullable = false)
     private Post post;
 

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Likes.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Likes.java
@@ -17,11 +17,11 @@ public class Likes extends BaseEntity {
     @Column(name = "like_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="post_id", nullable = false)
     private Post post;
 

--- a/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
@@ -51,7 +51,8 @@ public class LikeServiceImpl implements LikeService {
     @Override
     public LikeResponseDTO.LikeStatusDTO unlikePost(Long postId) {
         // 현재 로그인된 사용자 정보 가져오기
-        User user = securityUtil.getCurrentUser();
+        User user = userRepository.findById(securityUtil.getCurrentUser().getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));

--- a/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
@@ -29,7 +29,8 @@ public class LikeServiceImpl implements LikeService {
     @Override
     public LikeResponseDTO.LikeStatusDTO likePost(Long postId) {
         // 현재 로그인된 사용자 정보 가져오기
-        User user = securityUtil.getCurrentUser();
+        User user = userRepository.findById(securityUtil.getCurrentUser().getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -70,6 +70,7 @@ public class User extends BaseEntity {
     private Boolean isWithdrawn = false;
 
     @Column(nullable = false)
+    @Builder.Default
     private Boolean isActive = true; // true : 활성화, false : 비활성화
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/src/main/java/UMC_7th/Closit/domain/user/repository/init/UserInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/init/UserInit.java
@@ -43,6 +43,7 @@ public class UserInit implements ApplicationRunner {
                 .isWithdrawn(false)
                 .birth(LocalDate.EPOCH)
                 .role(Role.USER)
+                .isActive(true)
                 .countReport(0)
                 .build();
 
@@ -56,6 +57,7 @@ public class UserInit implements ApplicationRunner {
                 .birth(LocalDate.EPOCH)
                 .role(Role.USER)
                 .countReport(0)
+                .isActive(true)
                 .build();
 
         User user3 = User.builder()
@@ -68,6 +70,7 @@ public class UserInit implements ApplicationRunner {
                 .birth(LocalDate.EPOCH)
                 .role(Role.USER)
                 .countReport(0)
+                .isActive(true)
                 .build();
 
         users.add(user1);

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
@@ -18,12 +18,11 @@ public class UserWithdrawalScheduler {
     private final UserRepository userRepository;
 
     // 매일 새벽 3시에 실행 (cron: 초 분 시 일 월 요일)
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 0 3 * * *")
     @Transactional
     public void deleteExpiredWithdrawnUsers() {
-        LocalDateTime oneMinuteAgo = LocalDateTime.now().minusMinutes(1);
-
-        List<User> expiredUsers = userRepository.findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(oneMinuteAgo);
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+        List<User> expiredUsers = userRepository.findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(sevenDaysAgo);
         if (!expiredUsers.isEmpty()) {
             // 확인용 로그
             log.info("[UserWithdrawalScheduler] {}명의 탈퇴 유예 만료 계정 삭제", expiredUsers.size());

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserWithdrawalScheduler.java
@@ -18,11 +18,12 @@ public class UserWithdrawalScheduler {
     private final UserRepository userRepository;
 
     // 매일 새벽 3시에 실행 (cron: 초 분 시 일 월 요일)
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 * * * * *")
     @Transactional
     public void deleteExpiredWithdrawnUsers() {
-        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
-        List<User> expiredUsers = userRepository.findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(sevenDaysAgo);
+        LocalDateTime oneMinuteAgo = LocalDateTime.now().minusMinutes(1);
+
+        List<User> expiredUsers = userRepository.findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(oneMinuteAgo);
         if (!expiredUsers.isEmpty()) {
             // 확인용 로그
             log.info("[UserWithdrawalScheduler] {}명의 탈퇴 유예 만료 계정 삭제", expiredUsers.size());


### PR DESCRIPTION
## 🔗 연관된 이슈

- #273 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사용자 탈퇴 관련 오류 해결
    - likes, comment 엔티티에 `@ManyToOne(fetch = FetchType.LAZY)` 추가
    - notification과 sender (user)의 연관관계 제거 (senderId, senderName, senderImageUrl만 알림 전송 시에 DB에 저장)

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- DB에서 삭제된 거 확인 했습니당


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * Battle에서 관련된 ChallengeBattle 목록을 관리할 수 있는 기능이 추가되었습니다.
* **개선 사항**
  * 알림 기능이 발신자 정보를 간소화하여 효율적으로 개선되었습니다.
  * 알림 미리보기 정보가 수신자 중심으로 변경되어 명확해졌습니다.
  * 게시글, 댓글, 좋아요 관련 데이터 로딩이 지연 로딩 방식으로 변경되어 성능이 향상되었습니다.
  * 현재 로그인 사용자 정보 활용이 강화되어 알림 및 게시글 작성 시 안정성이 높아졌습니다.
* **버그 수정 및 안정성 개선**
  * 사용자 활성 상태 기본값 설정이 개선되어 사용자 관리가 안정화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->