### PR TITLE
fix: 사용자 탈퇴 오류

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Comment.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Comment.java
@@ -20,11 +20,11 @@ public class Comment extends BaseEntity {
     @Column(name = "comment_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="post_id", nullable = false)
     private Post post;
 

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Likes.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Likes.java
@@ -17,11 +17,11 @@ public class Likes extends BaseEntity {
     @Column(name = "like_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="post_id", nullable = false)
     private Post post;
 

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -115,7 +115,7 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL)
     @Builder.Default
-    private List<Notification> sendNotificationList = new ArrayList<>();
+    private List<Notification> sentNotificationList = new ArrayList<>();
 
     public User updateRole(Role newRole) {
         this.role = newRole;

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -70,6 +70,7 @@ public class User extends BaseEntity {
     private Boolean isWithdrawn = false;
 
     @Column(nullable = false)
+    @Builder.Default
     private Boolean isActive = true; // true : 활성화, false : 비활성화
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
@@ -111,6 +112,10 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Notification> notificationList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<Notification> sendNotificationList = new ArrayList<>();
 
     public User updateRole(Role newRole) {
         this.role = newRole;


### PR DESCRIPTION
## 🔗 연관된 이슈

- #273

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 사용자 탈퇴 관련 영속성 오류 해결
    - Likes, Comments에 `@ManyToOne(fetch = FetchType.LAZY)` 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 보낸 알림 목록을 별도로 관리할 수 있는 기능이 추가되었습니다.

* **개선 사항**
  * 알림 전송 시 사용자 정보와 게시글 정보의 데이터 로딩 방식이 최적화되었습니다.
  * 사용자 활성화 상태(isActive) 필드가 빌더 패턴 사용 시 기본값(true)으로 초기화되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->