### PR TITLE
feat: 해시태그, 하이라이트, 팔로우 관련 더미 데이터 생성 코드

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/init/BattleInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/init/BattleInit.java
@@ -1,4 +1,4 @@
-package UMC_7th.Closit.domain.battle.repository.init;
+package UMC_7th.Closit.domain.battle.init;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
 import UMC_7th.Closit.domain.battle.entity.enums.BattleStatus;
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(2)
+@Order(6)
 @DummyDataInit
 public class BattleInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/init/BattleInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/init/BattleInit.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(6)
+@Order(7)
 @DummyDataInit
 public class BattleInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/init/ChallengeBattleInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/init/ChallengeBattleInit.java
@@ -1,4 +1,4 @@
-package UMC_7th.Closit.domain.battle.repository.init;
+package UMC_7th.Closit.domain.battle.init;
 
 import UMC_7th.Closit.domain.battle.entity.Battle;
 import UMC_7th.Closit.domain.battle.entity.ChallengeBattle;
@@ -21,7 +21,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(3)
+@Order(7)
 @DummyDataInit
 public class ChallengeBattleInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/init/ChallengeBattleInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/init/ChallengeBattleInit.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(7)
+@Order(8)
 @DummyDataInit
 public class ChallengeBattleInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/follow/init/FollowInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/init/FollowInit.java
@@ -1,0 +1,81 @@
+package UMC_7th.Closit.domain.follow.init;
+
+import UMC_7th.Closit.domain.follow.entity.Follow;
+import UMC_7th.Closit.domain.follow.repository.FollowRepository;
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.UserRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
+import UMC_7th.Closit.global.util.DummyDataInit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(9)
+@DummyDataInit
+public class FollowInit implements ApplicationRunner {
+
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (followRepository.count() > 0) {
+            log.info("[Follow] 더미 데이터 존재");
+        } else {
+            saveFollows();
+        }
+    }
+
+    private void saveFollows() {
+        User user1 = userRepository.findById(1L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User user2 = userRepository.findById(2L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User user3 = userRepository.findById(3L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User user4 = userRepository.findById(4L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User user5 = userRepository.findById(5L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Follow> follows = new ArrayList<>();
+
+        // dummy1 follows 2,3,4,5
+        follows.add(Follow.builder().sender(user1).receiver(user2).build());
+        follows.add(Follow.builder().sender(user1).receiver(user3).build());
+        follows.add(Follow.builder().sender(user1).receiver(user4).build());
+        follows.add(Follow.builder().sender(user1).receiver(user5).build());
+
+        // dummy2 follows 1,3,4
+        follows.add(Follow.builder().sender(user2).receiver(user1).build());
+        follows.add(Follow.builder().sender(user2).receiver(user3).build());
+        follows.add(Follow.builder().sender(user2).receiver(user4).build());
+
+        // dummy3 follows 1,2
+        follows.add(Follow.builder().sender(user3).receiver(user1).build());
+        follows.add(Follow.builder().sender(user3).receiver(user2).build());
+
+        // dummy4 follows 1,5
+        follows.add(Follow.builder().sender(user4).receiver(user1).build());
+        follows.add(Follow.builder().sender(user4).receiver(user5).build());
+
+        // dummy5 follows 1,2,3
+        follows.add(Follow.builder().sender(user5).receiver(user1).build());
+        follows.add(Follow.builder().sender(user5).receiver(user2).build());
+        follows.add(Follow.builder().sender(user5).receiver(user3).build());
+
+        followRepository.saveAll(follows);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/follow/init/FollowInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/follow/init/FollowInit.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(9)
+@Order(1)
 @DummyDataInit
 public class FollowInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/highlight/init/HighlightInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/init/HighlightInit.java
@@ -4,6 +4,9 @@ import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.highlight.repository.HighlightRepository;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.post.repository.PostRepository;
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
 import UMC_7th.Closit.global.util.DummyDataInit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,13 +36,20 @@ public class HighlightInit implements ApplicationRunner {
     }
 
     private void saveHighlights() {
-        List<Post> posts = postRepository.findAll();
+        Post post1 = postRepository.findById(1L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        Post post2 = postRepository.findById(2L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        Post post3 = postRepository.findById(3L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
 
         List<Highlight> highlights = new ArrayList<>();
 
-        highlights.add(Highlight.builder().post(posts.get(0)).build());
-        highlights.add(Highlight.builder().post(posts.get(1)).build());
-        highlights.add(Highlight.builder().post(posts.get(2)).build());
+        highlights.add(Highlight.builder().post(post1).build());
+        highlights.add(Highlight.builder().post(post2).build());
+        highlights.add(Highlight.builder().post(post3).build());
 
         highlightRepository.saveAll(highlights);
     }

--- a/src/main/java/UMC_7th/Closit/domain/highlight/init/HighlightInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/init/HighlightInit.java
@@ -4,7 +4,6 @@ import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.highlight.repository.HighlightRepository;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.post.repository.PostRepository;
-import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
 import UMC_7th.Closit.global.util.DummyDataInit;
@@ -19,7 +18,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(8)
+@Order(9)
 @DummyDataInit
 public class HighlightInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/highlight/init/HighlightInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/init/HighlightInit.java
@@ -1,0 +1,46 @@
+package UMC_7th.Closit.domain.highlight.init;
+
+import UMC_7th.Closit.domain.highlight.entity.Highlight;
+import UMC_7th.Closit.domain.highlight.repository.HighlightRepository;
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.domain.post.repository.PostRepository;
+import UMC_7th.Closit.global.util.DummyDataInit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(8)
+@DummyDataInit
+public class HighlightInit implements ApplicationRunner {
+
+    private final PostRepository postRepository;
+    private final HighlightRepository highlightRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (highlightRepository.count() > 0) {
+            log.info("[Highlight] 더미 데이터 존재");
+        } else {
+            saveHighlights();
+        }
+    }
+
+    private void saveHighlights() {
+        List<Post> posts = postRepository.findAll();
+
+        List<Highlight> highlights = new ArrayList<>();
+
+        highlights.add(Highlight.builder().post(posts.get(0)).build());
+        highlights.add(Highlight.builder().post(posts.get(1)).build());
+        highlights.add(Highlight.builder().post(posts.get(2)).build());
+
+        highlightRepository.saveAll(highlights);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/init/HashtagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/HashtagInit.java
@@ -1,0 +1,42 @@
+package UMC_7th.Closit.domain.post.init;
+
+import UMC_7th.Closit.domain.post.entity.Hashtag;
+import UMC_7th.Closit.domain.post.repository.HashtagRepository;
+import UMC_7th.Closit.global.util.DummyDataInit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(1)
+@DummyDataInit
+public class HashtagInit implements ApplicationRunner {
+
+    private final HashtagRepository hashtagRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (hashtagRepository.count() > 0) {
+            log.info("[Hashtag] 더미 데이터 존재");
+        } else {
+            saveHashtags();
+        }
+    }
+
+    private void saveHashtags() {
+        List<Hashtag> hashtags = List.of(
+                Hashtag.builder().content("데일리룩").build(),
+                Hashtag.builder().content("여름코디").build(),
+                Hashtag.builder().content("시험기간룩").build(),
+                Hashtag.builder().content("심플").build(),
+                Hashtag.builder().content("깔끔한").build()
+        );
+
+        hashtagRepository.saveAll(hashtags);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/init/HashtagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/HashtagInit.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(1)
+@Order(2)
 @DummyDataInit
 public class HashtagInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/post/init/ItemTagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/ItemTagInit.java
@@ -1,0 +1,42 @@
+package UMC_7th.Closit.domain.post.init;
+
+import UMC_7th.Closit.domain.post.entity.ItemTag;
+import UMC_7th.Closit.domain.post.repository.ItemTagRepository;
+import UMC_7th.Closit.global.util.DummyDataInit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(2)
+@DummyDataInit
+public class ItemTagInit implements ApplicationRunner {
+
+    private final ItemTagRepository itemTagRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (itemTagRepository.count() > 0) {
+            log.info("[ItemTag] 더미 데이터 존재");
+        } else {
+            saveItemTags();
+        }
+    }
+
+    private void saveItemTags() {
+        List<ItemTag> itemTags = List.of(
+                ItemTag.builder().content("상의").build(),
+                ItemTag.builder().content("하의").build(),
+                ItemTag.builder().content("신발").build(),
+                ItemTag.builder().content("가방").build(),
+                ItemTag.builder().content("모자").build()
+        );
+
+        itemTagRepository.saveAll(itemTags);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/init/ItemTagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/ItemTagInit.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(2)
+@Order(3)
 @DummyDataInit
 public class ItemTagInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostHashtagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostHashtagInit.java
@@ -1,0 +1,86 @@
+package UMC_7th.Closit.domain.post.init;
+
+import UMC_7th.Closit.domain.post.entity.Hashtag;
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.domain.post.entity.PostHashtag;
+import UMC_7th.Closit.domain.post.repository.HashtagRepository;
+import UMC_7th.Closit.domain.post.repository.PostHashtagRepository;
+import UMC_7th.Closit.domain.post.repository.PostRepository;
+import UMC_7th.Closit.global.util.DummyDataInit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(4)
+@DummyDataInit
+public class PostHashtagInit implements ApplicationRunner {
+
+    private final PostRepository postRepository;
+    private final HashtagRepository hashtagRepository;
+    private final PostHashtagRepository postHashtagRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (postHashtagRepository.count() > 0) {
+            log.info("[PostHashtag] 더미 데이터 존재");
+        } else {
+            savePostHashtags();
+        }
+    }
+
+    private void savePostHashtags() {
+        List<Post> posts = postRepository.findAll();
+        List<Hashtag> hashtags = hashtagRepository.findAll();
+
+        List<PostHashtag> postHashtags = new ArrayList<>();
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(0))
+                .hashtag(hashtags.get(0))
+                .build());
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(0))
+                .hashtag(hashtags.get(4))
+                .build());
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(1))
+                .hashtag(hashtags.get(1))
+                .build());
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(1))
+                .hashtag(hashtags.get(3))
+                .build());
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(2))
+                .hashtag(hashtags.get(2))
+                .build());
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(3))
+                .hashtag(hashtags.get(3))
+                .build());
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(4))
+                .hashtag(hashtags.get(1))
+                .build());
+
+        postHashtags.add(PostHashtag.builder()
+                .post(posts.get(4))
+                .hashtag(hashtags.get(4))
+                .build());
+
+        postHashtagRepository.saveAll(postHashtags);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostHashtagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostHashtagInit.java
@@ -6,6 +6,8 @@ import UMC_7th.Closit.domain.post.entity.PostHashtag;
 import UMC_7th.Closit.domain.post.repository.HashtagRepository;
 import UMC_7th.Closit.domain.post.repository.PostHashtagRepository;
 import UMC_7th.Closit.domain.post.repository.PostRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
 import UMC_7th.Closit.global.util.DummyDataInit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +40,14 @@ public class PostHashtagInit implements ApplicationRunner {
     private void savePostHashtags() {
         List<Post> posts = postRepository.findAll();
         List<Hashtag> hashtags = hashtagRepository.findAll();
+
+        // 최소 개수 확인
+        if (posts.size() < 5) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+        if (hashtags.size() < 5) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
 
         List<PostHashtag> postHashtags = new ArrayList<>();
 

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostHashtagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostHashtagInit.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(4)
+@Order(5)
 @DummyDataInit
 public class PostHashtagInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostInit.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(3)
+@Order(4)
 @DummyDataInit
 public class PostInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostInit.java
@@ -1,4 +1,4 @@
-package UMC_7th.Closit.domain.post.repository.init;
+package UMC_7th.Closit.domain.post.init;
 
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.post.entity.Visibility;
@@ -19,7 +19,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(1)
+@Order(3)
 @DummyDataInit
 public class PostInit implements ApplicationRunner {
 
@@ -40,6 +40,12 @@ public class PostInit implements ApplicationRunner {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         User user2 = userRepository.findById(2L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User user4 = userRepository.findById(4L)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        User user5 = userRepository.findById(5L)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         List<Post> posts = new ArrayList<>();
@@ -74,9 +80,31 @@ public class PostInit implements ApplicationRunner {
                 .view(3)
                 .build();
 
+        Post post4 = Post.builder()
+                .user(user4)
+                .frontImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/post/front/60c0b9af-3fad-48e0-b46e-889dd264eac0.jpg")
+                .backImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/post/back/579aa421-4f0f-4eae-bc4c-d3cf3570f8df.jpg")
+                .pointColor("#ddffff")
+                .isMission(false)
+                .visibility(Visibility.PUBLIC)
+                .view(4)
+                .build();
+
+        Post post5 = Post.builder()
+                .user(user5)
+                .frontImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/post/front/60c0b9af-3fad-48e0-b46e-889dd264eac0.jpg")
+                .backImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/post/back/579aa421-4f0f-4eae-bc4c-d3cf3570f8df.jpg")
+                .pointColor("#ddffff")
+                .isMission(false)
+                .visibility(Visibility.PUBLIC)
+                .view(1)
+                .build();
+
         posts.add(post1);
         posts.add(post2);
         posts.add(post3);
+        posts.add(post4);
+        posts.add(post5);
 
         postRepository.saveAll(posts);
     }

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostItemTagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostItemTagInit.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
-@Order(5)
+@Order(6)
 @DummyDataInit
 public class PostItemTagInit implements ApplicationRunner {
 

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostItemTagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostItemTagInit.java
@@ -1,0 +1,110 @@
+package UMC_7th.Closit.domain.post.init;
+
+import UMC_7th.Closit.domain.post.entity.ItemTag;
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.domain.post.entity.PostItemTag;
+import UMC_7th.Closit.domain.post.repository.ItemTagRepository;
+import UMC_7th.Closit.domain.post.repository.PostItemTagRepository;
+import UMC_7th.Closit.domain.post.repository.PostRepository;
+import UMC_7th.Closit.global.util.DummyDataInit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Order(5)
+@DummyDataInit
+public class PostItemTagInit implements ApplicationRunner {
+
+    private final PostRepository postRepository;
+    private final ItemTagRepository itemTagRepository;
+    private final PostItemTagRepository postItemTagRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (postItemTagRepository.count() > 0) {
+            log.info("[PostItemTag] 더미 데이터 존재");
+        } else {
+            savePostItemTags();
+        }
+    }
+
+    private void savePostItemTags() {
+        List<Post> posts = postRepository.findAll();
+        List<ItemTag> itemTags = itemTagRepository.findAll();
+
+        List<PostItemTag> postItemTags = new ArrayList<>();
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(0))
+                .itemTag(itemTags.get(0))
+                .itemTagX(0.2)
+                .itemTagY(0.3)
+                .tagType("FRONT")
+                .build());
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(0))
+                .itemTag(itemTags.get(1))
+                .itemTagX(0.5)
+                .itemTagY(0.4)
+                .tagType("BACK")
+                .build());
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(1))
+                .itemTag(itemTags.get(1))
+                .itemTagX(0.5)
+                .itemTagY(0.4)
+                .tagType("BACK")
+                .build());
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(2))
+                .itemTag(itemTags.get(2))
+                .itemTagX(0.3)
+                .itemTagY(0.7)
+                .tagType("FRONT")
+                .build());
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(3))
+                .itemTag(itemTags.get(3))
+                .itemTagX(0.6)
+                .itemTagY(0.2)
+                .tagType("BACK")
+                .build());
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(3))
+                .itemTag(itemTags.get(0))
+                .itemTagX(0.2)
+                .itemTagY(0.3)
+                .tagType("FRONT")
+                .build());
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(4))
+                .itemTag(itemTags.get(4))
+                .itemTagX(0.1)
+                .itemTagY(0.5)
+                .tagType("FRONT")
+                .build());
+
+        postItemTags.add(PostItemTag.builder()
+                .post(posts.get(4))
+                .itemTag(itemTags.get(1))
+                .itemTagX(0.5)
+                .itemTagY(0.4)
+                .tagType("BACK")
+                .build());
+
+        postItemTagRepository.saveAll(postItemTags);
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/post/init/PostItemTagInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/init/PostItemTagInit.java
@@ -6,6 +6,8 @@ import UMC_7th.Closit.domain.post.entity.PostItemTag;
 import UMC_7th.Closit.domain.post.repository.ItemTagRepository;
 import UMC_7th.Closit.domain.post.repository.PostItemTagRepository;
 import UMC_7th.Closit.domain.post.repository.PostRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
 import UMC_7th.Closit.global.util.DummyDataInit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +40,14 @@ public class PostItemTagInit implements ApplicationRunner {
     private void savePostItemTags() {
         List<Post> posts = postRepository.findAll();
         List<ItemTag> itemTags = itemTagRepository.findAll();
+
+        // 최소 개수 확인
+        if (posts.size() < 5) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
+        if (itemTags.size() < 5) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
 
         List<PostItemTag> postItemTags = new ArrayList<>();
 

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -4,7 +4,6 @@ import UMC_7th.Closit.domain.battle.entity.BattleComment;
 import UMC_7th.Closit.domain.battle.entity.BattleLike;
 import UMC_7th.Closit.domain.battle.entity.Vote;
 import UMC_7th.Closit.domain.follow.entity.Follow;
-import UMC_7th.Closit.domain.highlight.entity.Highlight;
 import UMC_7th.Closit.domain.notification.entity.Notification;
 import UMC_7th.Closit.domain.post.entity.Bookmark;
 import UMC_7th.Closit.domain.post.entity.Comment;

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/User.java
@@ -69,6 +69,7 @@ public class User extends BaseEntity {
     private Boolean isWithdrawn = false;
 
     @Column(nullable = false)
+    @Builder.Default
     private Boolean isActive = true; // true : 활성화, false : 비활성화
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/src/main/java/UMC_7th/Closit/domain/user/init/UserInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/init/UserInit.java
@@ -38,7 +38,7 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy1")
                 .clositId("dummy1")
                 .email("dummy1@gmail.com")
-                .password("12345678")
+                .password("$2a$10$m2o4cOjvdoSEj0WrlKXiGOxyeGGdNH93Vga./LW0QPWvhQjzD1Ci2") // 12345678의 해시값
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
                 .isActive(true)
@@ -51,7 +51,7 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy2")
                 .clositId("dummy2")
                 .email("dummy2@gmail.com")
-                .password("12345678")
+                .password("$2a$10$m2o4cOjvdoSEj0WrlKXiGOxyeGGdNH93Vga./LW0QPWvhQjzD1Ci2") // 12345678의 해시값
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
                 .isActive(true)
@@ -64,7 +64,7 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy3")
                 .clositId("dummy3")
                 .email("dummy3@gmail.com")
-                .password("12345678")
+                .password("$2a$10$m2o4cOjvdoSEj0WrlKXiGOxyeGGdNH93Vga./LW0QPWvhQjzD1Ci2") // 12345678의 해시값
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
                 .isActive(true)
@@ -77,7 +77,7 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy4")
                 .clositId("dummy4")
                 .email("dummy4@gmail.com")
-                .password("12345678")
+                .password("$2a$10$m2o4cOjvdoSEj0WrlKXiGOxyeGGdNH93Vga./LW0QPWvhQjzD1Ci2") // 12345678의 해시값
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
                 .isActive(true)
@@ -90,7 +90,7 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy5")
                 .clositId("dummy5")
                 .email("dummy5@gmail.com")
-                .password("12345678")
+                .password("$2a$10$m2o4cOjvdoSEj0WrlKXiGOxyeGGdNH93Vga./LW0QPWvhQjzD1Ci2") // 12345678의 해시값
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
                 .isActive(true)

--- a/src/main/java/UMC_7th/Closit/domain/user/init/UserInit.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/init/UserInit.java
@@ -1,4 +1,4 @@
-package UMC_7th.Closit.domain.user.repository.init;
+package UMC_7th.Closit.domain.user.init;
 
 import UMC_7th.Closit.domain.user.entity.Role;
 import UMC_7th.Closit.domain.user.entity.User;
@@ -38,9 +38,10 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy1")
                 .clositId("dummy1")
                 .email("dummy1@gmail.com")
-                .password("123456")
+                .password("12345678")
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
+                .isActive(true)
                 .birth(LocalDate.EPOCH)
                 .role(Role.USER)
                 .countReport(0)
@@ -50,9 +51,10 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy2")
                 .clositId("dummy2")
                 .email("dummy2@gmail.com")
-                .password("123456")
+                .password("12345678")
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
+                .isActive(true)
                 .birth(LocalDate.EPOCH)
                 .role(Role.USER)
                 .countReport(0)
@@ -62,9 +64,36 @@ public class UserInit implements ApplicationRunner {
                 .name("dummy3")
                 .clositId("dummy3")
                 .email("dummy3@gmail.com")
-                .password("123456")
+                .password("12345678")
                 .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
                 .isWithdrawn(false)
+                .isActive(true)
+                .birth(LocalDate.EPOCH)
+                .role(Role.USER)
+                .countReport(0)
+                .build();
+
+        User user4 = User.builder()
+                .name("dummy4")
+                .clositId("dummy4")
+                .email("dummy4@gmail.com")
+                .password("12345678")
+                .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
+                .isWithdrawn(false)
+                .isActive(true)
+                .birth(LocalDate.EPOCH)
+                .role(Role.USER)
+                .countReport(0)
+                .build();
+
+        User user5 = User.builder()
+                .name("dummy5")
+                .clositId("dummy5")
+                .email("dummy5@gmail.com")
+                .password("12345678")
+                .profileImage("https://closit-bucket.s3.ap-northeast-2.amazonaws.com/default-user-profile.png")
+                .isWithdrawn(false)
+                .isActive(true)
                 .birth(LocalDate.EPOCH)
                 .role(Role.USER)
                 .countReport(0)
@@ -73,6 +102,8 @@ public class UserInit implements ApplicationRunner {
         users.add(user1);
         users.add(user2);
         users.add(user3);
+        users.add(user4);
+        users.add(user5);
 
         userRepository.saveAll(users);
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #266 

## 📝 작업 내용
- 해시태그, 아이템 태그 더미 데이터 생성 코드 작성
- 하이라이트 더미 데이터 생성 코드 작성
- 팔로우 더미 데이터 생성 코드 작성

**✨더미 데이터 생성 순서 정리: User -> Follow -> Hashtag -> ItemTag -> Post -> PostHashtag -> PostItemTag -> Battle -> ChallengeBattle -> Highlight**

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/e6df374f-37de-490c-aba3-e789bb3f2a9f)
![image](https://github.com/user-attachments/assets/db21963a-8cd0-4875-9aa1-f3ab22d3a3eb)
![image](https://github.com/user-attachments/assets/75a64083-12ab-4c4b-a218-adad9e58ca8d)
![image](https://github.com/user-attachments/assets/64228ca8-570f-45bf-9039-e50d29c2c103)
![image](https://github.com/user-attachments/assets/4991a4d3-9b68-4102-8a71-a96b091c4214)
![image](https://github.com/user-attachments/assets/527170f3-c4eb-4592-8ce6-4154bb83ea93)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * 더미 데이터 초기화를 위한 새로운 기능이 추가되었습니다: 해시태그, 아이템 태그, 게시글-해시태그, 게시글-아이템 태그, 팔로우, 하이라이트 더미 데이터가 앱 시작 시 자동으로 생성됩니다.
  * 게시글 더미 데이터에 신규 게시글 2건이 추가되었습니다.

* **Bug Fixes**
  * 기존 더미 사용자 데이터에 isActive 속성이 명시적으로 true로 설정되고, 비밀번호가 bcrypt 해시값으로 변경되었습니다.
  * 게시글 및 사용자 더미 데이터에 두 명의 신규 사용자가 추가되었습니다.

* **Refactor**
  * 일부 클래스의 패키지 구조와 실행 순서가 조정되었습니다.
  * User 엔티티에서 불필요한 import가 제거되고, isActive 필드에 기본값이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->