### PR TITLE
fix: 배틀 좋아요 수, 투표 수 동시성 문제

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -75,9 +75,9 @@ public class BattleConverter {
         return BattleResponseDTO.VoteBattleResultDTO.builder()
                 .battleId(vote.getBattle().getId())
                 .firstClositId(vote.getBattle().getPost1().getUser().getClositId())
-                .firstVotingRate(vote.getBattle().getFirstVotingRate())
+                .firstVotingCnt(vote.getBattle().getFirstVotingCnt())
                 .secondClositId(vote.getBattle().getPost2().getUser().getClositId())
-                .secondVotingRate(vote.getBattle().getSecondVotingRate())
+                .secondVotingCnt(vote.getBattle().getSecondVotingCnt())
                 .createdAt(vote.getBattle().getCreatedAt())
                 .build();
     }
@@ -93,13 +93,13 @@ public class BattleConverter {
                 .firstPostId(battle.getPost1().getId())
                 .firstPostFrontImage(battle.getPost1().getFrontImage())
                 .firstPostBackImage(battle.getPost1().getBackImage())
-                .firstVotingRate(battle.getFirstVotingRate())
+                .firstVotingCnt(battle.getFirstVotingCnt())
                 .secondClositId(battle.getPost2().getUser().getClositId())
                 .secondProfileImage(battle.getPost2().getUser().getProfileImage())
                 .secondPostId(battle.getPost2().getId())
                 .secondPostFrontImage(battle.getPost2().getFrontImage())
                 .secondPostBackImage(battle.getPost2().getBackImage())
-                .secondVotingRate(battle.getSecondVotingRate())
+                .secondVotingCnt(battle.getSecondVotingCnt())
                 .build();
     }
     public static BattleResponseDTO.BattlePreviewDTO battlePreviewDTO(Battle battle) { // 배틀 게시글 목록 조회
@@ -112,13 +112,13 @@ public class BattleConverter {
                 .firstPostId(battle.getPost1().getId())
                 .firstPostFrontImage(battle.getPost1().getFrontImage())
                 .firstPostBackImage(battle.getPost1().getBackImage())
-                .firstVotingRate(battle.getFirstVotingRate())
+                .firstVotingCnt(battle.getFirstVotingCnt())
                 .secondClositId(battle.getPost2().getUser().getClositId())
                 .secondProfileImage(battle.getPost2().getUser().getProfileImage())
                 .secondPostId(battle.getPost2().getId())
                 .secondPostFrontImage(battle.getPost2().getFrontImage())
                 .secondPostBackImage(battle.getPost2().getBackImage())
-                .secondVotingRate(battle.getSecondVotingRate())
+                .secondVotingCnt(battle.getSecondVotingCnt())
                 .build();
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -63,9 +63,9 @@ public class BattleResponseDTO {
     public static class VoteBattleResultDTO { // 배틀 투표
         private Long battleId;
         private String firstClositId;
-        private double firstVotingRate;
+        private double firstVotingCnt;
         private String secondClositId;
-        private double secondVotingRate;
+        private double secondVotingCnt;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
@@ -83,13 +83,13 @@ public class BattleResponseDTO {
         private Long firstPostId;
         private String firstPostFrontImage;
         private String firstPostBackImage;
-        private double firstVotingRate;
+        private double firstVotingCnt;
         private String secondClositId;
         private String secondProfileImage;
         private Long secondPostId;
         private String secondPostFrontImage;
         private String secondPostBackImage;
-        private double secondVotingRate;
+        private double secondVotingCnt;
     }
 
     @Builder
@@ -145,13 +145,13 @@ public class BattleResponseDTO {
         private Long firstPostId;
         private String firstPostFrontImage;
         private String firstPostBackImage;
-        private double firstVotingRate;
+        private double firstVotingCnt;
         private String secondClositId;
         private String secondProfileImage;
         private Long secondPostId;
         private String secondPostFrontImage;
         private String secondPostBackImage;
-        private double secondVotingRate;
+        private double secondVotingCnt;
     }
 
     @Builder

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -63,9 +63,9 @@ public class BattleResponseDTO {
     public static class VoteBattleResultDTO { // 배틀 투표
         private Long battleId;
         private String firstClositId;
-        private double firstVotingCnt;
+        private int firstVotingCnt;
         private String secondClositId;
-        private double secondVotingCnt;
+        private int secondVotingCnt;
         @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
         private LocalDateTime createdAt;
     }
@@ -83,13 +83,13 @@ public class BattleResponseDTO {
         private Long firstPostId;
         private String firstPostFrontImage;
         private String firstPostBackImage;
-        private double firstVotingCnt;
+        private int firstVotingCnt;
         private String secondClositId;
         private String secondProfileImage;
         private Long secondPostId;
         private String secondPostFrontImage;
         private String secondPostBackImage;
-        private double secondVotingCnt;
+        private int secondVotingCnt;
     }
 
     @Builder
@@ -145,13 +145,13 @@ public class BattleResponseDTO {
         private Long firstPostId;
         private String firstPostFrontImage;
         private String firstPostBackImage;
-        private double firstVotingCnt;
+        private int firstVotingCnt;
         private String secondClositId;
         private String secondProfileImage;
         private Long secondPostId;
         private String secondPostFrontImage;
         private String secondPostBackImage;
-        private double secondVotingCnt;
+        private int secondVotingCnt;
     }
 
     @Builder

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -32,16 +32,16 @@ public class Battle extends BaseEntity {
     private LocalDateTime deadline;
 
     @Column
-    private Integer firstVotingCnt;
+    private int firstVotingCnt = 0;
 
     @Column
-    private Integer secondVotingCnt;
+    private int secondVotingCnt = 0;
 
     @Column
-    private Integer likeCount;
+    private int likeCount = 0;
 
     @Column
-    private int viewCount;
+    private int viewCount = 0;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -85,7 +85,7 @@ public class Battle extends BaseEntity {
         return LocalDateTime.now().isAfter(deadline);
     }
 
-    public void updateVotingCnt(Integer firstVotingCnt, Integer secondVotingCnt) { // 배틀 게시글 목록 조회
+    public void updateVotingCnt(int firstVotingCnt, int secondVotingCnt) { // 배틀 게시글 목록 조회
         this.firstVotingCnt = firstVotingCnt;
         this.secondVotingCnt = secondVotingCnt;
     }

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -32,12 +32,10 @@ public class Battle extends BaseEntity {
     private LocalDateTime deadline;
 
     @Column
-    @Builder.Default
-    private Integer firstVotingCnt = 0;
+    private Integer firstVotingCnt;
 
     @Column
-    @Builder.Default
-    private Integer secondVotingCnt = 0;
+    private Integer secondVotingCnt;
 
     @Transient
     private double firstVotingRate;
@@ -91,14 +89,6 @@ public class Battle extends BaseEntity {
 
     public boolean availableVote () {
         return LocalDateTime.now().isAfter(deadline);
-    }
-
-    public void incrementFirstVotingCnt() { // 첫 번째 게시글 투표
-        this.firstVotingCnt++;
-    }
-
-    public void incrementSecondVotingCnt() { // 두 번째 게시글 투표
-        this.secondVotingCnt++;
     }
 
     public void updateVotingCnt(Integer firstVotingCnt, Integer secondVotingCnt) { // 배틀 게시글 목록 조회

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -46,8 +46,7 @@ public class Battle extends BaseEntity {
     private double secondVotingRate;
 
     @Column
-    @Builder.Default
-    private Integer likeCount = 0;
+    private Integer likeCount;
 
     @Column
     private int viewCount;
@@ -110,17 +109,5 @@ public class Battle extends BaseEntity {
     public void updateVotingRate (double firstVotingRate, double secondVotingRate) {
         this.firstVotingRate = firstVotingRate;
         this.secondVotingRate = secondVotingRate;
-    }
-
-    public void increaseLikeCount() { // 배틀 좋아요 생성
-        this.likeCount++;
-    }
-
-    public void decreaseLikeCount() { // 배틀 좋아요 삭제
-        if (this.likeCount == null) {
-            this.likeCount = 0;
-        } else {
-            this.likeCount--;
-        }
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/Battle.java
@@ -37,12 +37,6 @@ public class Battle extends BaseEntity {
     @Column
     private Integer secondVotingCnt;
 
-    @Transient
-    private double firstVotingRate;
-
-    @Transient
-    private double secondVotingRate;
-
     @Column
     private Integer likeCount;
 
@@ -94,10 +88,5 @@ public class Battle extends BaseEntity {
     public void updateVotingCnt(Integer firstVotingCnt, Integer secondVotingCnt) { // 배틀 게시글 목록 조회
         this.firstVotingCnt = firstVotingCnt;
         this.secondVotingCnt = secondVotingCnt;
-    }
-
-    public void updateVotingRate (double firstVotingRate, double secondVotingRate) {
-        this.firstVotingRate = firstVotingRate;
-        this.secondVotingRate = secondVotingRate;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleLike.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/entity/BattleLike.java
@@ -10,8 +10,6 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Getter
 @Builder
-@DynamicUpdate
-@DynamicInsert
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class BattleLike extends BaseEntity {

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
@@ -16,6 +16,18 @@ import java.util.Optional;
 public interface BattleRepository extends JpaRepository<Battle,Long> {
     @Modifying
     @Query("UPDATE Battle b " +
+            "SET b.likeCount = b.likeCount + 1 " +
+            "WHERE b.id = :id")
+    void incrementLikeCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Battle b " +
+            "SET b.likeCount = b.likeCount - 1 " +
+            "WHERE b.id = :id")
+    void decrementLikeCount(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Battle b " +
            "SET b.viewCount = b.viewCount + 1 " +
            "WHERE b.id = :id")
     void incrementViewCount(@Param("id") Long id);

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
@@ -28,6 +28,18 @@ public interface BattleRepository extends JpaRepository<Battle,Long> {
 
     @Modifying
     @Query("UPDATE Battle b " +
+            "SET b.firstVotingCnt = b.firstVotingCnt + 1 " +
+            "WHERE b.id = :id")
+    void incrementFirstVotingCnt(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Battle b " +
+            "SET b.secondVotingCnt = b.secondVotingCnt + 1 " +
+            "WHERE b.id = :id")
+    void incrementSecondVotingCnt(@Param("id") Long id);
+
+    @Modifying
+    @Query("UPDATE Battle b " +
            "SET b.viewCount = b.viewCount + 1 " +
            "WHERE b.id = :id")
     void incrementViewCount(@Param("id") Long id);

--- a/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/repository/BattleRepository.java
@@ -23,7 +23,8 @@ public interface BattleRepository extends JpaRepository<Battle,Long> {
     @Modifying
     @Query("UPDATE Battle b " +
             "SET b.likeCount = b.likeCount - 1 " +
-            "WHERE b.id = :id")
+            "WHERE b.id = :id " +
+            "AND b.likeCount > 0")
     void decrementLikeCount(@Param("id") Long id);
 
     @Modifying

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleLikeService/BattleLikeCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleLikeService/BattleLikeCommandServiceImpl.java
@@ -37,21 +37,19 @@ public class BattleLikeCommandServiceImpl implements BattleLikeCommandService {
             throw new GeneralException(ErrorStatus.BATTLE_LIKES_ALREADY_EXIST);
         }
 
-        battle.increaseLikeCount();
-
+        battleRepository.incrementLikeCount(battleId);
         return battleLikeRepository.save(battleLike);
     }
 
     @Override
     public void deleteBattleLike (Long userId, Long battleId) { // 배틀 좋아요 삭제
-        Battle battle = battleRepository.findById(battleId)
+        battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 
         BattleLike battleLike = battleLikeRepository.findByUserIdAndBattleId(userId, battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_LIKES_NOT_FOUND));
 
-        battle.decreaseLikeCount();
-
+        battleRepository.decrementLikeCount(battleId);
         battleLikeRepository.delete(battleLike);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -124,7 +124,10 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         } else if (battle.getPost2().getId().equals(vote.getVotedPostId())) { // 두 번째 게시글에 투표
             battleRepository.incrementSecondVotingCnt(battleId);
         }
-        battle.updateVotingCnt(battle.getFirstVotingCnt(), battle.getSecondVotingCnt());
+        Battle updatedBattle = battleRepository.findById(battleId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
+
+        battle.updateVotingCnt(updatedBattle.getFirstVotingCnt(), updatedBattle.getSecondVotingCnt());
 
         vote.voteBattle(user, battle, request.getPostId());
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -124,16 +124,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         } else if (battle.getPost2().getId().equals(vote.getVotedPostId())) { // 두 번째 게시글에 투표
             battleRepository.incrementSecondVotingCnt(battleId);
         }
-
-        Integer firstVotingCnt = battle.getFirstVotingCnt();
-        Integer secondVotingCnt = battle.getSecondVotingCnt();
-        int totalVoting = firstVotingCnt + secondVotingCnt;
-
-        // 투표 수 비율로 반환
-        double firstVotingPercentage = (totalVoting == 0) ? 0.0 : (firstVotingCnt * 100.0) / totalVoting;
-        double secondVotingPercentage = (totalVoting == 0) ? 0.0 : (secondVotingCnt * 100.0) / totalVoting;
-
-        battle.updateVotingRate(firstVotingPercentage, secondVotingPercentage);
+        battle.updateVotingCnt(battle.getFirstVotingCnt(), battle.getSecondVotingCnt());
 
         vote.voteBattle(user, battle, request.getPostId());
 

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleCommandServiceImpl.java
@@ -112,7 +112,7 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         Battle battle = battleRepository.findById(battleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BATTLE_NOT_FOUND));
 
-        Post post = postRepository.findById(request.getPostId())
+        postRepository.findById(request.getPostId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
 
         validateVoteBattle(battle, userId, request);
@@ -120,9 +120,9 @@ public class BattleCommandServiceImpl implements BattleCommandService {
         Vote vote = BattleConverter.toVote(user, request);
 
         if (battle.getPost1().getId().equals(vote.getVotedPostId())) { // 첫 번째 게시글에 투표
-            battle.incrementFirstVotingCnt();
+            battleRepository.incrementFirstVotingCnt(battleId);
         } else if (battle.getPost2().getId().equals(vote.getVotedPostId())) { // 두 번째 게시글에 투표
-            battle.incrementSecondVotingCnt();
+            battleRepository.incrementSecondVotingCnt(battleId);
         }
 
         Integer firstVotingCnt = battle.getFirstVotingCnt();

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -97,7 +97,7 @@ public class BattleQueryServiceImpl implements BattleQueryService {
     private void calculateVotes(Battle battle, Long userId) {
         boolean isVoted = voteRepository.existsByBattleIdAndUserId(battle.getId(), userId);
         if (!isVoted) { // 투표하지 않았으면 해당 배틀 투표 수 null로 표시
-            battle.updateVotingCnt(null, null);
+            battle.updateVotingCnt(0, 0);
         } else { // 투표했을 경우
             battle.updateVotingCnt(battle.getFirstVotingCnt(), battle.getSecondVotingCnt());
         }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -47,7 +47,6 @@ public class BattleQueryServiceImpl implements BattleQueryService {
     @Override
     public Slice<Battle> getBattleList(Integer page, BattleSorting battleSorting, BattleStatus battleStatus) { // 배틀 게시글 목록 조회
         User user = securityUtil.getCurrentUser();
-        Long userId = user.getId();
 
         Pageable pageable = PageRequest.of(page, 10, battleSorting.getSort());
 
@@ -55,7 +54,7 @@ public class BattleQueryServiceImpl implements BattleQueryService {
         Slice<Battle> battleList = battleRepository.findByPost2IsNotNullAndBattleStatus(pageable, battleStatus);
 
         battleList.forEach(battle -> {
-            calculateVotes(battle, userId);
+            calculateVotes(battle, user.getId());
         });
         return battleList;
     }
@@ -100,15 +99,7 @@ public class BattleQueryServiceImpl implements BattleQueryService {
         if (!isVoted) { // 투표하지 않았으면 해당 배틀 투표 수 null로 표시
             battle.updateVotingCnt(null, null);
         } else { // 투표했을 경우
-            Integer firstVotingCnt = battle.getFirstVotingCnt();
-            Integer secondVotingCnt = battle.getSecondVotingCnt();
-            int totalVoting = firstVotingCnt + secondVotingCnt;
-
-            // 투표 수 비율로 반환
-            double firstVotingPercentage = (totalVoting == 0) ? 0.0 : (firstVotingCnt * 100.0) / totalVoting;
-            double secondVotingPercentage = (totalVoting == 0) ? 0.0 : (secondVotingCnt * 100.0) / totalVoting;
-
-            battle.updateVotingRate(firstVotingPercentage, secondVotingPercentage);
+            battle.updateVotingCnt(battle.getFirstVotingCnt(), battle.getSecondVotingCnt());
         }
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/service/BattleService/BattleQueryServiceImpl.java
@@ -39,7 +39,7 @@ public class BattleQueryServiceImpl implements BattleQueryService {
 
         battleRepository.incrementViewCount(battle.getId());
 
-        calculateVotes(battle, user.getId());
+        updateVotingCntByUser(battle, user.getId());
 
         return battle;
     }
@@ -54,7 +54,7 @@ public class BattleQueryServiceImpl implements BattleQueryService {
         Slice<Battle> battleList = battleRepository.findByPost2IsNotNullAndBattleStatus(pageable, battleStatus);
 
         battleList.forEach(battle -> {
-            calculateVotes(battle, user.getId());
+            updateVotingCntByUser(battle, user.getId());
         });
         return battleList;
     }
@@ -88,13 +88,13 @@ public class BattleQueryServiceImpl implements BattleQueryService {
         Slice<Battle> votedBattleList = battleRepository.findVotedBattlesByUserAndPost2IsNotNull(user, pageable);
 
         votedBattleList.forEach(battle -> {
-            calculateVotes(battle, user.getId());
+            updateVotingCntByUser(battle, user.getId());
         });
 
         return votedBattleList;
     }
 
-    private void calculateVotes(Battle battle, Long userId) {
+    private void updateVotingCntByUser(Battle battle, Long userId) {
         boolean isVoted = voteRepository.existsByBattleIdAndUserId(battle.getId(), userId);
         if (!isVoted) { // 투표하지 않았으면 해당 배틀 투표 수 null로 표시
             battle.updateVotingCnt(0, 0);


### PR DESCRIPTION
## 🔗 연관된 이슈

- #276 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 배틀 좋아요 수, 투표 수 동시성 문제 수정
- 배틀 비율 관련 컬럼 및 메서드 삭제 (초반에는 사용자에게 비율을 보여줬는데 현재는 보여주지 않는 것으로 수정됨)

## 📸 스크린샷
- 투표 안했을 경우 0으로 보이고 했을 경우 투표 수가 보여서 프론트 측에서 반영할 수 있게 함
![image](https://github.com/user-attachments/assets/e93323b9-4b0d-4d25-952a-c83c43ec7465)


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 동시성 문제 쿼리 맞는지 함 봐주셨으면 좋겠습니다~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 투표 결과 및 상세 정보에서 투표율(%) 대신 투표 수(개수)로 표시되도록 변경되었습니다.

* **리팩터링**
  * 투표 및 좋아요 수 증가/감소 처리가 데이터베이스 레벨에서 직접 수행되도록 개선되었습니다.
  * 투표 관련 필드와 메서드가 단순화되어 관리가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->