### PR TITLE
fix: 조회수 한 시간 내 중복 조회 무시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// caffeine
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
 tasks.named('test') {

--- a/src/main/java/UMC_7th/Closit/global/infra/cache/ViewBlockCacheService.java
+++ b/src/main/java/UMC_7th/Closit/global/infra/cache/ViewBlockCacheService.java
@@ -1,0 +1,27 @@
+package UMC_7th.Closit.global.infra.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Service;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class ViewBlockCacheService {
+    private final Cache<String, Boolean> viewCache = Caffeine.newBuilder()
+            .expireAfterWrite(1, TimeUnit.HOURS)  // 1시간 동안 유지
+            .maximumSize(100_000)                // 최대 캐시 크기 설정
+            .build();
+
+    public boolean shouldIncreaseView(Long userId, Long postId) {
+        String key = generateKey(userId, postId);
+        if (viewCache.getIfPresent(key) != null) {
+            return false; // 이미 본 적 있음 → 증가 안 함
+        }
+        viewCache.put(key, true);
+        return true; // 처음 본 경우 → 증가 가능
+    }
+
+    private String generateKey(Long userId, Long postId) {
+        return userId + ":" + postId;
+    }
+}

--- a/src/main/java/UMC_7th/Closit/global/infra/cache/ViewBlockCacheService.java
+++ b/src/main/java/UMC_7th/Closit/global/infra/cache/ViewBlockCacheService.java
@@ -14,11 +14,8 @@ public class ViewBlockCacheService {
 
     public boolean shouldIncreaseView(Long userId, Long postId) {
         String key = generateKey(userId, postId);
-        if (viewCache.getIfPresent(key) != null) {
-            return false; // 이미 본 적 있음 → 증가 안 함
-        }
-        viewCache.put(key, true);
-        return true; // 처음 본 경우 → 증가 가능
+        Boolean previous = viewCache.asMap().putIfAbsent(key, true);
+        return previous == null; // 이전 값이 없으면 첫 조회
     }
 
     private String generateKey(Long userId, Long postId) {


### PR DESCRIPTION
## 🔗 연관된 이슈

- #259 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 동일 사용자의 반복 조회로 인한 조회수 중복 증가를 방지하기 위해 Caffeine 캐시를 적용했습니다.
- 캐시의 TTL은 1시간으로 설정되어, 동일 유저가 동일 게시글을 1시간 내 재조회할 경우 조회수는 증가하지 않습니다.

## 📸 스크린샷


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
레디스 쓰면 꼬일까봐 Caffeine을 사용해봤습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글 조회수 증가에 캐시 기반 제어 기능이 추가되어, 동일 사용자가 일정 시간 내 같은 게시글을 반복 조회해도 조회수가 중복으로 증가하지 않도록 개선되었습니다.

* **기타**
  * Caffeine 캐시 라이브러리가 새롭게 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->