### PR TITLE
feat: 좋아요 목록 조회

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/post/controller/LikeController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/LikeController.java
@@ -1,14 +1,12 @@
 package UMC_7th.Closit.domain.post.controller;
 
 import UMC_7th.Closit.domain.post.dto.LikeResponseDTO;
-import UMC_7th.Closit.domain.post.dto.PostResponseDTO;
 import UMC_7th.Closit.domain.post.service.LikeService;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/LikeController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/LikeController.java
@@ -1,10 +1,14 @@
 package UMC_7th.Closit.domain.post.controller;
 
 import UMC_7th.Closit.domain.post.dto.LikeResponseDTO;
+import UMC_7th.Closit.domain.post.dto.PostResponseDTO;
 import UMC_7th.Closit.domain.post.service.LikeService;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,5 +27,16 @@ public class LikeController {
     @DeleteMapping
     public ApiResponse<LikeResponseDTO.LikeStatusDTO> unlikePost(@PathVariable("post_id") Long postId){
         return ApiResponse.onSuccess(likeService.unlikePost(postId));
+    }
+
+    @Operation(summary = "게시글 좋아요한 유저 목록 조회")
+    @GetMapping("/list")
+    public ApiResponse<LikeResponseDTO.LikedUserListDTO> getLikedUsers(
+            @PathVariable("post_id") Long postId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ApiResponse.onSuccess(likeService.getLikedUsers(postId, pageable));
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/LikeConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/LikeConverter.java
@@ -1,8 +1,12 @@
 package UMC_7th.Closit.domain.post.converter;
 
 import UMC_7th.Closit.domain.post.dto.LikeResponseDTO;
+import UMC_7th.Closit.domain.post.entity.Likes;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.user.entity.User;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 public class LikeConverter {
     public static LikeResponseDTO.LikeStatusDTO toLikeStatusDTO(Post post, User user, boolean isLiked) {
@@ -10,6 +14,25 @@ public class LikeConverter {
                 .postId(post.getId())
                 .clositId(user.getClositId())
                 .isLiked(isLiked)
+                .build();
+    }
+
+    public static LikeResponseDTO.LikedUserDTO toLikedUserDTO(User user) {
+        return LikeResponseDTO.LikedUserDTO.builder()
+                .clositId(user.getClositId())
+                .name(user.getName())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
+
+    public static LikeResponseDTO.LikedUserListDTO toLikedUserListDTO(Slice<Likes> slice) {
+        List<LikeResponseDTO.LikedUserDTO> data = slice.stream()
+                .map(like -> toLikedUserDTO(like.getUser()))
+                .toList();
+
+        return LikeResponseDTO.LikedUserListDTO.builder()
+                .data(data)
+                .hasNext(slice.hasNext())
                 .build();
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/LikeResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/LikeResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class LikeResponseDTO {
     @Getter
     @Builder
@@ -14,5 +16,22 @@ public class LikeResponseDTO {
         private Boolean isLiked;
         private Long postId;
         private String clositId;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LikedUserDTO {
+        private String clositId;
+        private String name;
+        private String profileImage;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class LikedUserListDTO {
+        private List<LikedUserDTO> data;
+        private boolean hasNext;
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/LikeResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/LikeResponseDTO.java
@@ -21,6 +21,7 @@ public class LikeResponseDTO {
     @Getter
     @Builder
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class LikedUserDTO {
         private String clositId;
         private String name;
@@ -30,6 +31,7 @@ public class LikeResponseDTO {
     @Getter
     @Builder
     @AllArgsConstructor
+    @NoArgsConstructor
     public static class LikedUserListDTO {
         private List<LikedUserDTO> data;
         private boolean hasNext;

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/LikeRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/LikeRepository.java
@@ -3,6 +3,8 @@ package UMC_7th.Closit.domain.post.repository;
 import UMC_7th.Closit.domain.post.entity.Likes;
 import UMC_7th.Closit.domain.post.entity.Post;
 import UMC_7th.Closit.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +15,6 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
     boolean existsByUserAndPost(User user, Post post);
     
     Optional<Likes> findByUserAndPost(User user, Post post);
+
+    Slice<Likes> findByPost(Post post, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/LikeService.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/LikeService.java
@@ -1,8 +1,10 @@
 package UMC_7th.Closit.domain.post.service;
 
 import UMC_7th.Closit.domain.post.dto.LikeResponseDTO;
+import org.springframework.data.domain.Pageable;
 
 public interface LikeService {
     LikeResponseDTO.LikeStatusDTO likePost(Long postId);
     LikeResponseDTO.LikeStatusDTO unlikePost(Long postId);
+    LikeResponseDTO.LikedUserListDTO getLikedUsers(Long postId, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
@@ -13,6 +13,8 @@ import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.GeneralException;
 import UMC_7th.Closit.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,4 +65,14 @@ public class LikeServiceImpl implements LikeService {
         return LikeConverter.toLikeStatusDTO(post, user, false);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public LikeResponseDTO.LikedUserListDTO getLikedUsers(Long postId, Pageable pageable) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        Slice<Likes> likesSlice = likeRepository.findByPost(post, pageable);
+
+        return LikeConverter.toLikedUserListDTO(likesSlice);
+    }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #282 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 좋아요 목록 조회 api를 구현했습니다(후순위긴 합니다..)

## 📸 스크린샷


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 특정 게시글을 좋아요한 사용자 목록을 페이지네이션하여 조회할 수 있는 기능이 추가되었습니다.  
  * 각 사용자의 닉네임, 프로필 이미지 등 정보와 함께 다음 페이지 여부를 확인할 수 있습니다.  
  * 새로운 API 엔드포인트를 통해 좋아요한 사용자 리스트를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->