### PR TITLE
feat: 사용자 계정 검색 기능 구현

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/highlight/entity/Highlight.java
+++ b/src/main/java/UMC_7th/Closit/domain/highlight/entity/Highlight.java
@@ -1,7 +1,6 @@
 package UMC_7th.Closit.domain.highlight.entity;
 
 import UMC_7th.Closit.domain.post.entity.Post;
-import UMC_7th.Closit.domain.user.entity.User;
 import UMC_7th.Closit.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -14,17 +14,20 @@ import UMC_7th.Closit.global.s3.S3Service;
 import UMC_7th.Closit.security.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
 @Slf4j
+@Validated
 public class UserController {
 
     private final SecurityUtil securityUtil;
@@ -252,7 +255,7 @@ public class UserController {
         """)
     @GetMapping("/search")
     public ApiResponse<UserResponseDTO.UserSearchListDTO> searchUsers(
-            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "keyword") @Size(min = 1, max = 50, message = "검색어는 1자 이상 50자 이하여야 합니다") String keyword,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -239,4 +239,24 @@ public class UserController {
         userCommandService.deactivateUser(deactivateUserDTO);
         return ApiResponse.onSuccess("사용자가 비활성화되었습니다.");
     }
+
+    @Operation(summary = "사용자 검색",
+            description = """
+        ## 사용자 Closit ID 검색
+        사용자의 Closit ID를 기준으로 부분 일치하는 계정을 페이징하여 조회합니다.
+        
+        ### Request Parameters
+        - keyword (string): 검색할 사용자 Closit ID 문자열 (부분 일치)
+        - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
+        - size (기본값: 10): 페이지당 항목 수
+        """)
+    @GetMapping("/search")
+    public ApiResponse<UserResponseDTO.UserSearchListDTO> searchUsers(
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Slice<User> userSlice = userQueryService.searchUsersByClositId(keyword, PageRequest.of(page, size));
+        return ApiResponse.onSuccess(UserConverter.toUserSearchListDTO(userSlice));
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -127,4 +127,20 @@ public class UserConverter {
                 .build();
     }
 
+    public static UserResponseDTO.UserSearchListDTO toUserSearchListDTO(Slice<User> userSlice) {
+        List<UserResponseDTO.UserSearchDTO> userSearchDTOs = userSlice.getContent().stream()
+                .map(user -> UserResponseDTO.UserSearchDTO.builder()
+                        .clositId(user.getClositId())
+                        .name(user.getName())
+                        .profileImage(user.getProfileImage())
+                        .build())
+                .collect(Collectors.toList());
+
+        return UserResponseDTO.UserSearchListDTO.builder()
+                .searchedUsers(userSearchDTOs)
+                .hasNext(userSlice.hasNext())
+                .pageNumber(userSlice.getNumber())
+                .size(userSlice.getSize())
+                .build();
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
@@ -195,4 +195,24 @@ public class UserResponseDTO {
         private boolean isBlocked;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserSearchListDTO {
+        private List<UserSearchDTO> searchedUsers;
+        private boolean hasNext;
+        private int pageNumber; // 페이지 번호
+        private int size; // 페이지 당 조회 개수
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserSearchDTO {
+        private String clositId;
+        private String name;
+        private String profileImage;
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/repository/UserRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/UserRepository.java
@@ -35,6 +35,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(LocalDateTime dateTime);
 
-    @Query("SELECT u FROM User u WHERE u.clositId LIKE %:query%")
-    Slice<User> searchByClositId(String query, Pageable pageable);
+    @Query("SELECT u FROM User u WHERE LOWER(u.clositId) LIKE LOWER(CONCAT('%', :query, '%'))")
+    Slice<User> searchByClositId(@Param("query") String query, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/repository/UserRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package UMC_7th.Closit.domain.user.repository;
 
 import UMC_7th.Closit.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -32,4 +34,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     void incrementReportCount(@Param("id") Long id);
 
     List<User> findByIsWithdrawnTrueAndWithdrawalRequestedAtBefore(LocalDateTime dateTime);
+
+    @Query("SELECT u FROM User u WHERE u.clositId LIKE %:query%")
+    Slice<User> searchByClositId(String query, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
@@ -25,4 +25,6 @@ public interface UserQueryService {
     Slice<User> getBlockedUserList(Pageable pageable);
 
     UserResponseDTO.IsBlockedDTO isBlockedBy(String targetClositId);
+
+    Slice<User> searchUsersByClositId(String query, Pageable pageable);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -115,4 +115,9 @@ public class UserQueryServiceImpl implements UserQueryService {
 
         return isblockedDTO;
     }
+
+    @Override
+    public Slice<User> searchUsersByClositId(String query, Pageable pageable) {
+        return userRepository.searchByClositId(query, pageable);
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -118,6 +118,9 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     @Override
     public Slice<User> searchUsersByClositId(String query, Pageable pageable) {
+        if (query == null || query.trim().isEmpty()) {
+            return userRepository.findAll(pageable);
+        }
         return userRepository.searchByClositId(query, pageable);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #284 

## 📝 작업 내용
- 사용자 계정 검색 기능 구현

아직 기본 쿼리 LIKE를 사용한 단순 부분 일치 여부(대소문자 구분X)를 통해서 검색이 됩니다.
오타 허용, 자동 완성 등의 고급 검색 기능은 추후 Elasticsearch를 도입하여 구현할 예정입니다.

## 📸 스크린샷
![스크린샷 2025-07-02 181936](https://github.com/user-attachments/assets/b104d7b3-af87-43ba-a0c3-26a4747e647f)
![스크린샷 2025-07-02 182013](https://github.com/user-attachments/assets/5b92dc3d-b6a5-40af-8ba1-533a2a7f2bf5)
![스크린샷 2025-07-02 182337](https://github.com/user-attachments/assets/fe83a13e-b02f-4bcb-955b-0ca1cb04d012)
![스크린샷 2025-07-02 182350](https://github.com/user-attachments/assets/8eaf8913-e896-4a48-ad7f-31b2ea6315fe)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * Closit ID로 사용자를 검색할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 검색 결과는 페이지네이션과 함께 사용자의 Closit ID, 이름, 프로필 이미지를 포함합니다.  
* **문서화**
  * 사용자 검색 API에 대한 OpenAPI 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->