### PR TITLE
fix: 인증 필터 예외 대상 API 경로 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/emailtoken/service/EmailTokenServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/emailtoken/service/EmailTokenServiceImpl.java
@@ -37,7 +37,7 @@ public class EmailTokenServiceImpl implements EmailTokenService {
         emailTokenRepository.save(emailToken);
 
         // 이메일 발송
-        String verificationLink = serverDomain + "/api/auth/email-tokens/verify?token=" + token;
+        String verificationLink = serverDomain + "/api/v1/email-tokens/verify?token=" + token;
         emailService.sendEmail(email, "[Closit] 이메일 인증을 완료해주세요", verificationLink);
     }
 

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -49,9 +49,9 @@ public class SecurityConfig {
                                          "/api/auth/login",
                                          "/api/auth/refresh",
                                          "/api/auth/users/isunique/**",
-                                         "/api/auth/email-tokens/**",
                                          "/api/auth/find-id",
                                          "/api/auth/reset-password",
+                                         "/api/v1/email-tokens/**",
                                          "/email-verification-success.html",
                                          "/email-verification-failed.html",
                                          "/api/auth/oauth/**").permitAll()


### PR DESCRIPTION
## 🔗 연관된 이슈
- #286 

## 📝 작업 내용
- `SecurityConfig` 파일에서 인증 필터 예외 대상 API 경로를 `api/v1/...`으로 수정함.

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/b0c32ca9-0622-46a7-9d0d-924594013562)
![image](https://github.com/user-attachments/assets/bd3b9292-0408-446d-8b92-8c86e9483b33)
![image](https://github.com/user-attachments/assets/0706c96c-f3ab-4da4-9fc3-8f5be76b9037)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **버그 수정**
  * 이메일 토큰 관련 API 요청의 허용 경로가 "/api/v1/email-tokens/**"로 변경되어 인증 없이 접근이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->