### PR TITLE
fix: 오늘의 옷장 api 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/todaycloset/repository/TodayClosetRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/todaycloset/repository/TodayClosetRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface TodayClosetRepository extends JpaRepository<TodayCloset, Long> {
     Page<TodayCloset> findAll(Pageable pageable);
@@ -16,4 +19,31 @@ public interface TodayClosetRepository extends JpaRepository<TodayCloset, Long> 
     Slice<TodayCloset> findAllOrderByPostView(Pageable pageable);
     @Query("SELECT tc FROM TodayCloset tc ORDER BY tc.createdAt DESC")
     Slice<TodayCloset> findAllOrderByCreatedAt(Pageable pageable);
+
+    // 조회수 순 정렬 (24시간 이내)
+    @Query("""
+    SELECT tc 
+    FROM TodayCloset tc 
+    JOIN tc.post p 
+    WHERE tc.createdAt BETWEEN :start AND :end 
+    ORDER BY p.view DESC
+    """)
+    Slice<TodayCloset> findTodayClosetsOrderByPostView(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable
+    );
+
+    // 최신순 정렬 (24시간 이내)
+    @Query("""
+    SELECT tc 
+    FROM TodayCloset tc 
+    WHERE tc.createdAt BETWEEN :start AND :end 
+    ORDER BY tc.createdAt DESC
+    """)
+    Slice<TodayCloset> findTodayClosetsByCreatedAtBetween(
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable
+    );
 }

--- a/src/main/java/UMC_7th/Closit/domain/todaycloset/service/TodayClosetQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/todaycloset/service/TodayClosetQueryServiceImpl.java
@@ -36,22 +36,27 @@ public class TodayClosetQueryServiceImpl implements TodayClosetQueryService {
     public Slice<TodayCloset> getTodayClosetList(Integer page, String sort) {
         Pageable pageable = PageRequest.of(page, 10);
 
+        // 현재 시점 기준 24시간 내
+        LocalDateTime start = LocalDateTime.now().minusHours(24);
+        LocalDateTime end = LocalDateTime.now();
+
         if (sort.equals("view")) {
-            return todayClosetRepository.findAllOrderByPostView(pageable);
+            return todayClosetRepository.findTodayClosetsOrderByPostView(start, end, pageable);
         } else if (sort.equals("latest")) {
-            return todayClosetRepository.findAllOrderByCreatedAt(pageable);
+            return todayClosetRepository.findTodayClosetsByCreatedAtBetween(start, end, pageable);
         } else {
             throw new GeneralException(ErrorStatus.INVALID_TODAY_CLOSET_SORT);
         }
     }
+
 
     @Override
     public List<TodayClosetResponseDTO.TodayClosetCandidateDTO> getTodayClosetCandidates() {
         User currentUser = securityUtil.getCurrentUser();
 
         // 오늘 날짜의 시작과 끝
-        LocalDateTime start = LocalDate.now().atStartOfDay();
-        LocalDateTime end = LocalDate.now().atTime(LocalTime.MAX);
+        LocalDateTime start = LocalDateTime.now().minusHours(24);
+        LocalDateTime end = LocalDateTime.now();
 
         // 오늘 하루 동안 작성된 게시글 전체 조회
         List<Post> todaysPosts = postRepository.findAllByUserIdAndCreatedAtBetween(currentUser.getId(), start, end);


### PR DESCRIPTION
## 🔗 연관된 이슈

- #288 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 오늘의 옷장 조회 API에 최근 24시간 이내 생성된 게시글만 조회되도록 필터링 로직 추가

- 조회 정렬 기준으로 latest(최신순)과 view(조회수 순) 모두 적용되도록 쿼리 수정

- 후보군 조회 API(GET /candidates)도 24시간 이내 게시글만 대상으로 하도록 수정

## 📸 스크린샷


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 최근 24시간 내에 생성된 TodayCloset 게시글을 조회할 수 있는 정렬 옵션(조회수순, 최신순)이 추가되었습니다.

* **버그 수정**
  * TodayCloset 목록과 후보 조회 시 기존의 '오늘 하루' 기준에서 '최근 24시간' 기준으로 변경되어 더 정확한 결과를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->