### PR TITLE
feat: 사용자 로그아웃

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
@@ -38,6 +38,11 @@ public class UserAuthController {
         return ApiResponse.onSuccess(jwtResponse);
     }
 
+    @PostMapping("/logout")
+    public ApiResponse<String> logout() {
+
+    }
+
     @Operation(summary = "소셜 로그인", description = "소셜 로그인 API")
     @PostMapping("/oauth/{socialLoginType}")
     public ApiResponse<JwtResponse> socialLogin(@PathVariable SocialLoginType socialLoginType, @RequestBody OAuthLoginRequestDTO socialLoginRequestDTO) {
@@ -78,4 +83,6 @@ public class UserAuthController {
 
         return ApiResponse.onSuccess("비밀번호가 성공적으로 변경되었습니다.");
     }
+
+
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
@@ -6,8 +6,12 @@ import UMC_7th.Closit.domain.user.entity.Role;
 import UMC_7th.Closit.domain.user.service.UserAuthService;
 import UMC_7th.Closit.domain.user.service.UserCommandService;
 import UMC_7th.Closit.global.apiPayload.ApiResponse;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
 import UMC_7th.Closit.global.common.SocialLoginType;
+import UMC_7th.Closit.security.jwt.JwtTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +27,7 @@ public class UserAuthController {
     private final UserCommandService userCommandService;
     private final UserAuthService userAuthService;
     private final EmailTokenService emailTokenService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/register")
     public ApiResponse<RegisterResponseDTO> register (@RequestBody @Valid UserRequestDTO.CreateUserDTO userRequestDto){
@@ -39,8 +44,16 @@ public class UserAuthController {
     }
 
     @PostMapping("/logout")
-    public ApiResponse<String> logout() {
+    public ApiResponse<String> logout(HttpServletRequest request) {
+        log.info("Logout entry");
+        String accessToken = jwtTokenProvider.resolveToken(request);
+        log.info("Access Token: {}", accessToken);
+        if (accessToken == null) {
+            throw new UserHandler(ErrorStatus._UNAUTHORIZED);
+        }
 
+        userAuthService.logout(accessToken);
+        return ApiResponse.onSuccess("로그아웃이 완료되었습니다.");
     }
 
     @Operation(summary = "소셜 로그인", description = "소셜 로그인 API")

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
@@ -45,9 +45,7 @@ public class UserAuthController {
 
     @PostMapping("/logout")
     public ApiResponse<String> logout(HttpServletRequest request) {
-        log.info("Logout entry");
         String accessToken = jwtTokenProvider.resolveToken(request);
-        log.info("Access Token: {}", accessToken);
         if (accessToken == null) {
             throw new UserHandler(ErrorStatus._UNAUTHORIZED);
         }

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -77,7 +77,7 @@ public class UserController {
     @Operation(summary = "사용자 정보 조회", description = "특정 사용자의 정보를 조회합니다.")
     @GetMapping("/{closit_id}")
     @CheckBlocked(targetIdParam = "closit_id")
-    public ApiResponse<UserResponseDTO.UpdateUserInfoDTO> getUserInfo (@PathVariable String closit_id) {
+    public ApiResponse<UserResponseDTO.UpdateUserInfoDTO> getUserInfo (@PathVariable("closit_id") String closit_id) {
         return ApiResponse.onSuccess(userQueryService.getUserInfo(closit_id));
     }
 
@@ -126,7 +126,7 @@ public class UserController {
     @CheckBlocked(targetIdParam = "closit_id")
     @GetMapping("/{closit_id}/followers")
     public ApiResponse<UserResponseDTO.UserFollowerSliceDTO> getUserFollowers (
-            @PathVariable String closit_id,
+            @PathVariable("closit_id") String closit_id,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
@@ -149,7 +149,7 @@ public class UserController {
     @CheckBlocked(targetIdParam = "closit_id")
     @GetMapping("/{closit_id}/following")
     public ApiResponse<UserResponseDTO.UserFollowingSliceDTO> getUserFollowing(
-            @PathVariable String closit_id,
+            @PathVariable("closit_id") String closit_id,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
@@ -172,7 +172,7 @@ public class UserController {
     @CheckBlocked(targetIdParam = "closit_id")
     @GetMapping("/{closit_id}/highlights")
     public ApiResponse<UserResponseDTO.UserHighlightSliceDTO> getUserHighlights(
-            @PathVariable String closit_id,
+            @PathVariable("closit_id") String closit_id,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
 
@@ -200,7 +200,7 @@ public class UserController {
             - closit_id: 중복 여부를 확인할 Closit ID
             """)
     @GetMapping("/isunique/{closit_id}")
-    public ApiResponse<Boolean> isUniqueClositId(@PathVariable String closit_id) {
+    public ApiResponse<Boolean> isUniqueClositId(@PathVariable("closit_id") String closit_id) {
         return ApiResponse.onSuccess(userCommandService.isClositIdUnique(closit_id));
     }
 

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/TokenBlackList.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/TokenBlackList.java
@@ -3,14 +3,21 @@ package UMC_7th.Closit.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 
 @Entity
 @Builder
+@Table(
+        name = "token_black_list",
+        indexes = {
+                @Index(name = "idx_access_token", columnList = "accessToken")
+        }
+)
 @NoArgsConstructor
 @AllArgsConstructor
+@Getter
 public class TokenBlackList {
 
     @Id
@@ -26,8 +33,12 @@ public class TokenBlackList {
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    @Column(nullable = false)
+    private LocalDateTime expiredAt;
+
     @PrePersist
     public void onCreate() {
         this.createdAt = LocalDateTime.now();
+        this.expiredAt = LocalDateTime.now().plusHours(7);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/entity/TokenBlackList.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/entity/TokenBlackList.java
@@ -1,0 +1,33 @@
+package UMC_7th.Closit.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenBlackList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String accessToken;
+
+    @Column(nullable = false)
+    private String clositId;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    public void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/user/repository/TokenBlackListRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/TokenBlackListRepository.java
@@ -1,0 +1,13 @@
+package UMC_7th.Closit.domain.user.repository;
+
+import UMC_7th.Closit.domain.user.entity.TokenBlackList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TokenBlackListRepository extends JpaRepository<TokenBlackList, Long> {
+
+    boolean existsByAccessToken(String accessToken);
+
+    void deleteByAccessToken(String accessToken);
+}

--- a/src/main/java/UMC_7th/Closit/domain/user/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/RefreshTokenServiceImpl.java
@@ -35,7 +35,6 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
 
     @Override
     public void deleteRefreshToken(String username) {
-
         refreshTokenRepository.deleteByUsername(username);
     }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthService.java
@@ -20,4 +20,6 @@ public interface UserAuthService {
     void resetPassword(String email, String newPassword);
   
     JwtResponse socialLogin (SocialLoginType socialLoginType, OAuthLoginRequestDTO oauthLoginRequestDTO);
+
+    void logout (String accessToken);
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
@@ -144,7 +144,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
     @Override
     public JwtResponse socialLogin (SocialLoginType socialLoginType, OAuthLoginRequestDTO oauthLoginRequestDTO) {
-        // Client에서 전달된 idToken을 통해 유저 정보 가져오기
+        // Client에서 전달된 idToken을 통해 유저 정보 가져옴
         String idToken = oauthLoginRequestDTO.getIdToken();
         OAuthUserInfo userInfo;
 
@@ -171,7 +171,6 @@ public class UserAuthServiceImpl implements UserAuthService {
 
     @Override
     public void logout (String accessToken) {
-        jwtTokenProvider.validateToken(accessToken);
         Claims claims = jwtTokenProvider.getClaims(accessToken);
         String email = claims.getSubject();
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
@@ -175,7 +175,6 @@ public class UserAuthServiceImpl implements UserAuthService {
         Claims claims = jwtTokenProvider.getClaims(accessToken);
         String email = claims.getSubject();
 
-
         RefreshToken refreshToken = refreshTokenRepository.findByUsername(email)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -2,7 +2,6 @@ package UMC_7th.Closit.security;
 
 import UMC_7th.Closit.security.jwt.JwtAccessDeniedHandler;
 import UMC_7th.Closit.security.jwt.JwtAuthenticationEntryPoint;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package UMC_7th.Closit.security;
 
 import UMC_7th.Closit.security.jwt.JwtAccessDeniedHandler;
 import UMC_7th.Closit.security.jwt.JwtAuthenticationEntryPoint;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,8 +40,15 @@ public class SecurityConfig {
                 // 폼 기반 로그인 설정
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(logout -> logout
+                        .logoutUrl("/api/auth/logout")
                         .logoutSuccessUrl("/")
-                        .invalidateHttpSession(true))
+                        .invalidateHttpSession(true)
+                        .logoutSuccessHandler((request, response, authentication) -> {
+                            HttpSession session = request.getSession();
+                            session.invalidate();
+                        })
+                        .permitAll()
+                )
                 // 경로 접속 권한 설정
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
                         // Swagger, login, register, refresh 허용

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -34,21 +34,11 @@ public class SecurityConfig {
                 .exceptionHandling((exceptionHandling) -> exceptionHandling
                         .accessDeniedHandler(jwtAccessDeniedHandler) // 인증은 되었지만 권한이 부족할 때
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)) // 인증에 실패했을 때
-                // disable session management
+                // Session management 비활성화
                 .sessionManagement((sessionManagement) -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // 폼 기반 로그인 설정
                 .formLogin(AbstractHttpConfigurer::disable)
-                .logout(logout -> logout
-                        .logoutUrl("/api/auth/logout")
-                        .logoutSuccessUrl("/")
-                        .invalidateHttpSession(true)
-                        .logoutSuccessHandler((request, response, authentication) -> {
-                            HttpSession session = request.getSession();
-                            session.invalidate();
-                        })
-                        .permitAll()
-                )
                 // 경로 접속 권한 설정
                 .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
                         // Swagger, login, register, refresh 허용

--- a/src/main/java/UMC_7th/Closit/security/SecurityUtil.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityUtil.java
@@ -29,9 +29,4 @@ public class SecurityUtil {
                 () -> new UserHandler(ErrorStatus.USER_NOT_FOUND)
         );
     }
-
-    public boolean isAuthenticated(){
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return authentication != null && authentication.isAuthenticated() && !"anonymousUser".equals(authentication.getPrincipal());
-    }
 }

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
@@ -3,7 +3,6 @@ package UMC_7th.Closit.security.jwt;
 import UMC_7th.Closit.domain.user.entity.Role;
 import UMC_7th.Closit.domain.user.repository.TokenBlackListRepository;
 import UMC_7th.Closit.domain.user.service.CustomUserDetailService;
-import UMC_7th.Closit.security.blacklist.TokenBlackListRepository; // 🔹 블랙리스트 레포 추가
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,7 +11,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -29,7 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailService customUserDetailsService;
-    private final TokenBlackListRepository tokenBlackListRepository; // 🔹 추가
+    private final TokenBlackListRepository tokenBlackListRepository;
 
     @Override
     protected void doFilterInternal(
@@ -56,7 +54,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
-            // 🔹 2. 토큰 유효성 검사
+            // 2. 토큰 유효성 검사
             if (jwtTokenProvider.validateToken(token)) {
                 Claims claims = jwtTokenProvider.getClaims(token);
                 String email = claims.getSubject();

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
@@ -46,7 +46,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String token = resolveToken(request);
-        String header = request.getHeader("Authorization");
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Claims claims = jwtTokenProvider.getClaims(token);

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
@@ -48,17 +48,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
         String header = request.getHeader("Authorization");
 
-//        log.info("🔍 [JwtAuthenticationFilter] - Incoming Request: {}", request.getRequestURI());
-//        log.info("🔍 [JwtAuthenticationFilter] - Authorization Header: {}", header);
-//        log.info("🔍 [JwtAuthenticationFilter] - Extracted Token: {}", token);
-
-
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Claims claims = jwtTokenProvider.getClaims(token);
             String email = claims.getSubject();
             String roleString = claims.get("role", String.class);
-            Date issuedAt = claims.getIssuedAt();
-            Date expiration = claims.getExpiration();
 
             Role role = Role.valueOf(roleString); // String->Role 반환
             UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
@@ -38,10 +38,6 @@ public class JwtTokenProvider {
         Date issuedAt = Date.from(now);
         Date expiration = Date.from(now.plusMillis(validity));
 
-        log.info("🔑 Creating JWT Token...");
-        log.info("🕒 Issued At: {}", issuedAt);
-        log.info("⏳ Expiration: {}", expiration);
-
         return Jwts.builder()
                 .setSubject(email)
                 .claim("role", role)
@@ -67,10 +63,6 @@ public class JwtTokenProvider {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException e) {
-            log.info("-------------------- JwtTokenProvider.getClaims ---------------------");
-            log.info("⏳ Expired Token: {}", token);
-            log.info("⏳ Expired At: {}", e.getClaims().getExpiration());
-            log.info("⏳ Current Time: {}", new Date(System.currentTimeMillis()));
             return e.getClaims();
         }
     }
@@ -87,18 +79,12 @@ public class JwtTokenProvider {
 
             return true;
         } catch (ExpiredJwtException e) {
-            log.info("⏳ Expired Token: {}", token);
-            log.info("⏳ Expired At: {}", e.getClaims().getExpiration());
-            log.info("⏳ Current Time: {}", new Date(System.currentTimeMillis()));
             throw new UserHandler(ErrorStatus.EXPIRED_TOKEN);
         } catch (MalformedJwtException e) {
-            log.info("🚨 Malformed Token: {}", token);
             throw new JwtHandler(ErrorStatus.INVALID_TOKEN);
         } catch (UnsupportedJwtException e) {
-            log.info("🚨 Unsupported Token: {}", token);
             throw new JwtHandler(ErrorStatus.UNSUPPORTED_TOKEN);
         } catch (IllegalArgumentException e) {
-            log.info("🚨 Empty Token: {}", token);
             throw new JwtHandler(ErrorStatus.EMPTY_TOKEN);
         }
     }

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
@@ -70,8 +70,6 @@ public class JwtTokenProvider {
 
     public boolean validateToken(String token) {
         try {
-            Claims claims = getClaims(token);
-
             Jwts.parserBuilder()
                     .setSigningKey(key)
                     // .setAllowedClockSkewSeconds(60) // Clock Skew 적용 (1분 오차 허용)
@@ -99,10 +97,6 @@ public class JwtTokenProvider {
 
     }
 
-    public String getUserName(String token) {
-        Claims claims = getClaims(token);
-        return claims.getSubject();
-    }
 }
 
 

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
@@ -6,6 +6,7 @@ import UMC_7th.Closit.global.apiPayload.exception.handler.JwtHandler;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -89,6 +90,19 @@ public class JwtTokenProvider {
         }
     }
 
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+
+    }
+
+    public String getUserName(String token) {
+        Claims claims = getClaims(token);
+        return claims.getSubject();
+    }
 }
 
 


### PR DESCRIPTION
## 🔗 연관된 이슈

- #265 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 로그아웃 시 해당 유저의 refreshToken을 refreshToken DB 테이블에서 삭제
- accessToken 악용 방지를 위해 blacklist 엔티티 생성
- `JwtAuthenticationFilter`에서 blacklist 토큰 필터링
- 로그아웃 성공 시 "로그아웃이 완료되었습니다" string 값 반환

## 📸 스크린샷
1. 로그아웃 전 refreshToken 테이블에 저장된 token 값
![image](https://github.com/user-attachments/assets/05823855-12ff-4da2-a4e1-a046628221a1)
2. 로그아웃 후 삭제된 refreshToken
![image](https://github.com/user-attachments/assets/994da8de-1f97-403f-a4e2-02e77d129560)
3. 로그아웃 후 blacklist에 추가된 accessToken
![image](https://github.com/user-attachments/assets/1b115cf7-e37c-45d6-bb5e-66dde09fc1c8)
4. 로그아웃 후 다른 api 접근 거부 확인
![image](https://github.com/user-attachments/assets/7af17bb2-eec9-4f5f-b081-9407f98346ce)


## 💬 리뷰 요구사항
- 로그아웃 할 때마다 DB 접근해서 추가, 삭제 작업을 하게 되므로 Redis 추후 도입 필요할 것 같습니다.
- blacklist 토큰이 DB에 많이 쌓였을 때 탐색 비효율성이 증가하므로 추후 스케줄러를 도입하여 일정 주기마다 필요 없는 blacklist 토큰을 삭제하는 기능을 추가하는 것이 필요해보입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 로그아웃 엔드포인트가 추가되어 사용자가 로그아웃할 수 있습니다.
  * 로그아웃 시 토큰이 블랙리스트에 등록되어, 이후 해당 토큰으로 인증이 불가합니다.
  * 토큰 블랙리스트 기능이 도입되어, 블랙리스트에 등록된 토큰은 인증에서 차단됩니다.

* **버그 수정**
  * 인증 필터에서 블랙리스트에 등록된 토큰 사용 시 401 오류를 반환하도록 개선되었습니다.

* **기타**
  * 사용자 관련 일부 API에서 URL 경로 변수의 명시적 이름 지정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->