### PR TITLE
fix: 파라미터 명 명시 및 차단 목록 조회 코드 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,15 @@ dependencies {
 	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
+tasks.withType(JavaCompile) {
+	options.compilerArgs = ['-parameters']
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 	systemProperty 'file.encoding', 'UTF-8'
 }
+
 
 jar {
 	enabled = false

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -256,8 +256,8 @@ public class UserController {
     @GetMapping("/search")
     public ApiResponse<UserResponseDTO.UserSearchListDTO> searchUsers(
             @RequestParam(name = "keyword") @Size(min = 1, max = 50, message = "검색어는 1자 이상 50자 이하여야 합니다") String keyword,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
     ) {
         Slice<User> userSlice = userQueryService.searchUsersByClositId(keyword, PageRequest.of(page, size));
         return ApiResponse.onSuccess(UserConverter.toUserSearchListDTO(userSlice));

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserController.java
@@ -98,10 +98,10 @@ public class UserController {
     @Operation(summary = "사용자 차단 목록 조회", description = "특정 사용자의 차단 목록을 조회합니다.")
     @GetMapping("/blocks")
     public ApiResponse<UserResponseDTO.UserBlockListDTO> getBlockedUserList(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
 
-        Slice<User> blockedUserSlice = userQueryService.getBlockedUserList(PageRequest.of(page, size));
+        Slice<String> blockedUserSlice = userQueryService.getBlockedUserList(PageRequest.of(page, size));
         return ApiResponse.onSuccess(UserConverter.toUserBlockListDTO(blockedUserSlice));
     }
 
@@ -127,8 +127,8 @@ public class UserController {
     @GetMapping("/{closit_id}/followers")
     public ApiResponse<UserResponseDTO.UserFollowerSliceDTO> getUserFollowers (
             @PathVariable("closit_id") String closit_id,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Slice<User> followerSlice = userQueryService.getFollowerList(closit_id, PageRequest.of(page, size));
         return ApiResponse.onSuccess(UserConverter.toUserFollowerSliceDTO(followerSlice));
@@ -150,8 +150,8 @@ public class UserController {
     @GetMapping("/{closit_id}/following")
     public ApiResponse<UserResponseDTO.UserFollowingSliceDTO> getUserFollowing(
             @PathVariable("closit_id") String closit_id,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Slice<User> followingSlice = userQueryService.getFollowingList(closit_id, PageRequest.of(page, size));
         return ApiResponse.onSuccess(UserConverter.toUserFollowingSliceDTO(followingSlice));
@@ -173,8 +173,8 @@ public class UserController {
     @GetMapping("/{closit_id}/highlights")
     public ApiResponse<UserResponseDTO.UserHighlightSliceDTO> getUserHighlights(
             @PathVariable("closit_id") String closit_id,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Slice<Highlight> highlightSlice = userQueryService.getHighlightList(closit_id, PageRequest.of(page, size));
 

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -109,13 +109,11 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.UserBlockListDTO toUserBlockListDTO(Slice<User> blockedUserSlice) {
+    public static UserResponseDTO.UserBlockListDTO toUserBlockListDTO(Slice<String> blockedUserSlice) {
         List<UserResponseDTO.UserBlockDTO> blockedUserList =
                 blockedUserSlice.getContent().stream()
-                        .map(user -> UserResponseDTO.UserBlockDTO.builder()
-                                .clositId(user.getClositId())
-                                .name(user.getName())
-                                .profileImage(user.getProfileImage())
+                        .map(clositId -> UserResponseDTO.UserBlockDTO.builder()
+                                .clositId(clositId)
                                 .build())
                         .collect(Collectors.toList());
 

--- a/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/dto/UserResponseDTO.java
@@ -183,8 +183,6 @@ public class UserResponseDTO {
     @AllArgsConstructor
     public static class UserBlockDTO {
         private String clositId;
-        private String name;
-        private String profileImage;
     }
 
     @Builder

--- a/src/main/java/UMC_7th/Closit/domain/user/repository/BlockRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/BlockRepository.java
@@ -16,6 +16,6 @@ public interface BlockRepository extends JpaRepository<Block, Long> {
     Optional<Block> findByBlockerIdAndBlockedId (String blockerId, String blockedId);
 
     @Query("SELECT b.blockedId FROM Block b WHERE b.blockerId = :blockerId")
-    Slice<User> findBlockedUsersByBlocker(@Param("blockerId") String blockerId, Pageable pageable);
+    Slice<String> findBlockedUsersByBlocker(@Param("blockerId") String blockerId, Pageable pageable);
 
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryService.java
@@ -22,7 +22,7 @@ public interface UserQueryService {
 
     Slice<Post> getRecentPostList(String clositId, Integer page); // 특정 사용자의 최근 게시글 조회
 
-    Slice<User> getBlockedUserList(Pageable pageable);
+    Slice<String> getBlockedUserList(Pageable pageable);
 
     UserResponseDTO.IsBlockedDTO isBlockedBy(String targetClositId);
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -96,7 +96,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
-    public Slice<User> getBlockedUserList(Pageable pageable) {
+    public Slice<String> getBlockedUserList(Pageable pageable) {
         User currentUser = securityUtil.getCurrentUser();
         return userBlockRepository.findBlockedUsersByBlocker(currentUser.getClositId(), pageable);
     }


### PR DESCRIPTION
## 🔗 연관된 이슈

- #291 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 차단 목록 조회를 포함한 UserController api에서 파라미터 명 명시 안된 부분 명시
- 차단 목록 조회시 User 객체를 조회해서 발생하는 convert 오류 수정

## 📸 스크린샷
1. 차단 여부 조회
![image](https://github.com/user-attachments/assets/83c62d69-aefb-417a-a8e7-066a8b0a8900)
2. 차단 목록 조회
![image](https://github.com/user-attachments/assets/c20991aa-a6d4-469d-abe8-23134ec00ee2)


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 차단된 사용자 목록에서 사용자 이름과 프로필 이미지가 더 이상 제공되지 않고, 사용자 ID만 반환됩니다.
  * 차단된 사용자 목록 관련 일부 API의 반환 데이터 구조가 간소화되었습니다.
  * 페이지네이션 파라미터의 명칭이 명확하게 지정되어 요청 시 혼동이 줄어듭니다.

* **기타**
  * 내부 빌드 설정이 일부 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->