### PR TITLE
fix: 게시글 부모 댓글 ID response 포함

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/post/converter/CommentConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/CommentConverter.java
@@ -32,6 +32,7 @@ public class CommentConverter {
     public static CommentResponseDTO.CommentPreviewDTO commentPreviewDTO(Comment comment) {
         return CommentResponseDTO.CommentPreviewDTO.builder()
                 .commentId(comment.getId())
+                .parentCommentId(comment.getParent() != null ? comment.getParent().getId() : null)
                 .clositId(comment.getUser().getClositId())
                 .content(comment.getContent())
                 .isParent(comment.isParent())

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/CommentResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/CommentResponseDTO.java
@@ -28,6 +28,7 @@ public class CommentResponseDTO {
     public static class CommentPreviewDTO { // 댓글 조회
         private String clositId;
         private Long commentId;
+        private Long parentCommentId;
         private String content;
         private boolean isParent;
         private List<CommentPreviewDTO> replies;


### PR DESCRIPTION
## 🔗 연관된 이슈

- #293 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 게시글 부모 댓글 ID response 포함

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/595ecc8b-120e-40ab-bbd6-1bcb314146b8)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 댓글 미리보기에서 부모 댓글의 ID를 확인할 수 있는 `parentCommentId` 항목이 추가되었습니다.  
* **버그 수정**
  * 없음  
* **기타**
  * 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->