### PR TITLE
feat: 배틀, 게시글 response 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/converter/BattleConverter.java
@@ -106,6 +106,7 @@ public class BattleConverter {
         return BattleResponseDTO.BattlePreviewDTO.builder()
                 .battleId(battle.getId())
                 .isLiked(!battle.getBattleLikesList().isEmpty())
+                .likeCount(battle.getLikeCount())
                 .title(battle.getTitle())
                 .firstClositId(battle.getPost1().getUser().getClositId())
                 .firstProfileImage(battle.getPost1().getUser().getProfileImage())

--- a/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/battle/dto/BattleDTO/BattleResponseDTO.java
@@ -77,6 +77,7 @@ public class BattleResponseDTO {
     public static class BattlePreviewDTO { // 배틀 게시글 목록, 내가 투표한 게시글 목록 조회
         private Long battleId;
         private boolean isLiked;
+        private int likeCount;
         private String title;
         private String firstClositId;
         private String firstProfileImage;

--- a/src/main/java/UMC_7th/Closit/domain/post/converter/PostConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/converter/PostConverter.java
@@ -41,7 +41,7 @@ public class PostConverter {
         return PostResponseDTO.PostPreviewDTO.builder()
                 .postId(post.getId())
                 .clositId(post.getUser().getClositId())
-                .userName(post.getUser().getName())
+                .likeCount(post.getLikes())
                 .profileImage(post.getUser().getProfileImage())
                 .frontImage(post.getFrontImage())
                 .backImage(post.getBackImage())

--- a/src/main/java/UMC_7th/Closit/domain/post/dto/PostResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/dto/PostResponseDTO.java
@@ -43,7 +43,7 @@ public class PostResponseDTO {
     public static class PostPreviewDTO { // 게시글 목록 조회
         private Long postId;
         private String clositId;
-        private String userName;
+        private int likeCount;
         private String profileImage;
         private String frontImage;
         private String backImage;

--- a/src/main/java/UMC_7th/Closit/domain/post/entity/Post.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/entity/Post.java
@@ -39,6 +39,9 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private boolean isMission;
 
+    @Column
+    private int likes = 0;
+
     @Builder.Default
     @Column(nullable = false)
     private int view = 0;

--- a/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/repository/PostRepository.java
@@ -6,6 +6,7 @@ import UMC_7th.Closit.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -53,4 +54,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p WHERE p.visibility = :visibility AND p.user = :user")
     Slice<Post> findByVisibilityAndUser(@Param("visibility") Visibility visibility, @Param("user") User user, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.likes = p.likes + 1 WHERE p.id = :id")
+    void incrementLikeCount(@Param("id") Long id);
 }

--- a/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/service/LikeServiceImpl.java
@@ -43,6 +43,9 @@ public class LikeServiceImpl implements LikeService {
         Likes likes = Likes.createLikes(user, post);
         likeRepository.save(likes);
 
+        // 좋아요 수 증가
+        postRepository.incrementLikeCount(postId);
+
         // 좋아요 알림
         notiCommandService.likeNotification(likes);
 

--- a/src/main/java/UMC_7th/Closit/domain/todaycloset/converter/TodayClosetConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/todaycloset/converter/TodayClosetConverter.java
@@ -24,7 +24,7 @@ public class TodayClosetConverter {
 
     public static TodayClosetResponseDTO.TodayClosetPreviewDTO toPreviewDTO(TodayCloset todayCloset) {
         return TodayClosetResponseDTO.TodayClosetPreviewDTO.builder()
-                .clositId(todayCloset.getPost().getUser().getId())
+                .clositId(todayCloset.getPost().getUser().getClositId())
                 .todayClosetId(todayCloset.getId())
                 .postId(todayCloset.getPost().getId())
                 .likes(todayCloset.getPost().getLikes())

--- a/src/main/java/UMC_7th/Closit/domain/todaycloset/converter/TodayClosetConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/todaycloset/converter/TodayClosetConverter.java
@@ -24,8 +24,10 @@ public class TodayClosetConverter {
 
     public static TodayClosetResponseDTO.TodayClosetPreviewDTO toPreviewDTO(TodayCloset todayCloset) {
         return TodayClosetResponseDTO.TodayClosetPreviewDTO.builder()
+                .clositId(todayCloset.getPost().getUser().getId())
                 .todayClosetId(todayCloset.getId())
                 .postId(todayCloset.getPost().getId())
+                .likes(todayCloset.getPost().getLikes())
                 .frontImage(todayCloset.getPost().getFrontImage())
                 .backImage(todayCloset.getPost().getBackImage())
                 .viewCount(todayCloset.getPost().getView())

--- a/src/main/java/UMC_7th/Closit/domain/todaycloset/dto/TodayClosetResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/todaycloset/dto/TodayClosetResponseDTO.java
@@ -22,7 +22,7 @@ public class TodayClosetResponseDTO {
     @NoArgsConstructor
     @Builder
     public static class TodayClosetPreviewDTO {
-        private Long clositId;
+        private String clositId;
         private Long todayClosetId;
         private Long postId;
         private int likes;

--- a/src/main/java/UMC_7th/Closit/domain/todaycloset/dto/TodayClosetResponseDTO.java
+++ b/src/main/java/UMC_7th/Closit/domain/todaycloset/dto/TodayClosetResponseDTO.java
@@ -22,8 +22,10 @@ public class TodayClosetResponseDTO {
     @NoArgsConstructor
     @Builder
     public static class TodayClosetPreviewDTO {
+        private Long clositId;
         private Long todayClosetId;
         private Long postId;
+        private int likes;
         private String frontImage;
         private String backImage;
         private Integer viewCount;


### PR DESCRIPTION
## 🔗 연관된 이슈

- #298 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->

- 배틀, 게시글, 오늘의 옷장 response 수정

## 📸 스크린샷
- 오늘의 옷장
![image](https://github.com/user-attachments/assets/9c40a0a2-9ac5-41ff-b949-e9ab39271248)

- 배틀 
![image](https://github.com/user-attachments/assets/b0ad6deb-3e47-4472-87e1-c3c0a11784dc)


- 게시글
![image](https://github.com/user-attachments/assets/fa4563ec-a741-4917-b051-59065c6d87d1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 배틀 미리보기, 게시글 미리보기, 오늘의 옷장 미리보기에서 좋아요 수(likeCount/likes)가 표시됩니다.
  * 오늘의 옷장 미리보기에 clositId(사용자 ID)가 추가로 표시됩니다.

* **버그 수정**
  * 게시글 미리보기에서 기존의 사용자 이름 대신 좋아요 수가 노출되도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->