### PR TITLE
refactor: 사용자 관련 코드 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 	implementation 'com.google.api-client:google-api-client:1.34.1'
 	implementation 'com.google.http-client:google-http-client-gson:1.41.5'
-	testImplementation 'org.springframework.security:spring-security-test'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -41,8 +41,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'org.mockito:mockito-core:5.3.1'
 	testImplementation 'org.mockito:mockito-junit-jupiter:5.3.1'
-
-
 
 	// JWT
 	implementation "io.jsonwebtoken:jjwt-api:0.11.5"

--- a/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
+++ b/src/main/java/UMC_7th/Closit/domain/post/controller/PostController.java
@@ -53,8 +53,6 @@ public class PostController {
                     4. 성공 후, 게시글 업로드 API에 Presigned Url의 쿼리 파라미터를 제외하고 업로드 요청
                     """)
     public ApiResponse<PostResponseDTO.GetPresignedUrlDTO> getPresignedUrl(@RequestBody @Valid PostRequestDTO.GetPresignedUrlDTO request) {
-        User user = securityUtil.getCurrentUser();
-
         String frontImageUrl = s3Service.getPresignedUrl(postFrontPath, request.getFrontImageUrl());
         String backImageUrl = s3Service.getPresignedUrl(postBackPath, request.getBackImageUrl());
 

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserAccountController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserAccountController.java
@@ -1,0 +1,42 @@
+package UMC_7th.Closit.domain.user.controller;
+
+import UMC_7th.Closit.domain.user.dto.UserRequestDTO;
+import UMC_7th.Closit.domain.user.service.UserCommandService;
+import UMC_7th.Closit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Slf4j
+@Validated
+public class UserAccountController {
+
+    private final UserCommandService userCommandService;
+
+    @Operation(summary = "사용자 탈퇴 취소", description = "탈퇴 유예 기간 내 탈퇴를 취소(계정 복구)합니다.")
+    @PostMapping("/withdrawal/cancel")
+    public ApiResponse<String> cancelWithdrawal() {
+        userCommandService.cancelWithdrawal();
+        return ApiResponse.onSuccess("탈퇴가 취소되어 계정이 복구되었습니다.");
+    }
+
+    @Operation(summary = "사용자 탈퇴 요청", description = "사용자가 탈퇴를 요청하면 7일 유예 상태로 변경됩니다.")
+    @PostMapping("/withdrawal")
+    public ApiResponse<String> requestWithdrawal() {
+        userCommandService.deleteUser();
+        return ApiResponse.onSuccess("탈퇴 요청이 정상적으로 처리되었습니다. 7일 이내에 취소하지 않으면 계정이 완전히 삭제됩니다.");
+    }
+
+    @Operation(summary = "사용자 비활성화", description = "특정 사용자를 비활성화합니다.")
+    @PatchMapping("/deactivate")
+    public ApiResponse<String> deactivateUser(@RequestBody @Valid UserRequestDTO.DeactivateUserDTO deactivateUserDTO) {
+        userCommandService.deactivateUser(deactivateUserDTO);
+        return ApiResponse.onSuccess("사용자가 비활성화되었습니다.");
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
@@ -70,10 +70,10 @@ public class UserAuthController {
         return ApiResponse.onSuccess(jwtResponse);
     }
 
-    @PatchMapping("/{user_id}/role")
+    @PatchMapping("/{closit_id}/role")
     @PreAuthorize("hasRole('ADMIN')")
-    public ApiResponse<UserResponseDTO.UserInfoDTO> changeRole(@PathVariable Long user_id, @RequestParam Role newRole) {
-        UserResponseDTO.UserInfoDTO userInfoDTO = userAuthService.updateUserRole(user_id, newRole);
+    public ApiResponse<UserResponseDTO.UserInfoDTO> changeRole(@PathVariable("closit_id") String clositId, @RequestParam Role newRole) {
+        UserResponseDTO.UserInfoDTO userInfoDTO = userAuthService.updateUserRole(clositId, newRole);
 
         return ApiResponse.onSuccess(userInfoDTO);
     }

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
@@ -65,7 +65,6 @@ public class UserAuthController {
     @PostMapping("/refresh")
     public ApiResponse<JwtResponse> refresh(@RequestBody RefreshRequestDTO refreshRequestDTO) {
         String refreshToken = refreshRequestDTO.getRefreshToken();
-
         JwtResponse jwtResponse = userAuthService.refresh(refreshToken);
 
         return ApiResponse.onSuccess(jwtResponse);

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserAuthController.java
@@ -46,19 +46,18 @@ public class UserAuthController {
     @PostMapping("/logout")
     public ApiResponse<String> logout(HttpServletRequest request) {
         String accessToken = jwtTokenProvider.resolveToken(request);
-        if (accessToken == null) {
-            throw new UserHandler(ErrorStatus._UNAUTHORIZED);
-        }
+        if (accessToken == null) throw new UserHandler(ErrorStatus._UNAUTHORIZED);
 
         userAuthService.logout(accessToken);
         return ApiResponse.onSuccess("로그아웃이 완료되었습니다.");
     }
 
     @Operation(summary = "소셜 로그인", description = "소셜 로그인 API")
-    @PostMapping("/oauth/{socialLoginType}")
-    public ApiResponse<JwtResponse> socialLogin(@PathVariable SocialLoginType socialLoginType, @RequestBody OAuthLoginRequestDTO socialLoginRequestDTO) {
-        JwtResponse jwtResponse = userAuthService.socialLogin(socialLoginType, socialLoginRequestDTO);
-
+    @PostMapping("/oauth/{provider}/login")
+    public ApiResponse<JwtResponse> socialLogin(
+            @PathVariable("provider") SocialLoginType provider,
+            @RequestBody @Valid OAuthLoginRequestDTO dto) {
+        JwtResponse jwtResponse = userAuthService.socialLogin(provider, dto);
         return ApiResponse.onSuccess(jwtResponse);
     }
 
@@ -68,14 +67,6 @@ public class UserAuthController {
         JwtResponse jwtResponse = userAuthService.refresh(refreshToken);
 
         return ApiResponse.onSuccess(jwtResponse);
-    }
-
-    @PatchMapping("/{closit_id}/role")
-    @PreAuthorize("hasRole('ADMIN')")
-    public ApiResponse<UserResponseDTO.UserInfoDTO> changeRole(@PathVariable("closit_id") String clositId, @RequestParam Role newRole) {
-        UserResponseDTO.UserInfoDTO userInfoDTO = userAuthService.updateUserRole(clositId, newRole);
-
-        return ApiResponse.onSuccess(userInfoDTO);
     }
 
     @Operation(summary = "Closit ID 찾기", description = "이메일 인증을 완료한 사용자에 한해 Closit ID를 조회합니다.")
@@ -94,5 +85,11 @@ public class UserAuthController {
         return ApiResponse.onSuccess("비밀번호가 성공적으로 변경되었습니다.");
     }
 
+    @PatchMapping("/{clositId}/role")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResponse<UserResponseDTO.UserInfoDTO> changeRole(@PathVariable("clositId") String clositId, @RequestParam Role newRole) {
+        UserResponseDTO.UserInfoDTO userInfoDTO = userAuthService.updateUserRole(clositId, newRole);
 
+        return ApiResponse.onSuccess(userInfoDTO);
+    }
 }

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserContentController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserContentController.java
@@ -1,0 +1,67 @@
+package UMC_7th.Closit.domain.user.controller;
+
+import UMC_7th.Closit.domain.highlight.entity.Highlight;
+import UMC_7th.Closit.domain.post.entity.Post;
+import UMC_7th.Closit.domain.user.converter.UserConverter;
+import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
+import UMC_7th.Closit.domain.user.service.UserQueryService;
+import UMC_7th.Closit.global.apiPayload.ApiResponse;
+import UMC_7th.Closit.global.validation.annotation.CheckBlocked;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Slf4j
+@Validated
+public class UserContentController {
+    private final UserQueryService userQueryService;
+
+    @Operation(summary = "사용자의 하이라이트 목록 조회",
+            description = """
+            ## 사용자의 하이라이트 목록 조회
+            특정 사용자가 등록한 하이라이트 게시글 목록을 페이징하여 조회합니다.
+
+            ### PathVariable
+            - closit_id: 하이라이트 목록을 조회할 사용자의 Closit ID
+
+            ### Request Parameters
+            - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
+            - size (기본값: 10): 페이지당 항목 수
+            """)
+    @CheckBlocked(targetIdParam = "closit_id")
+    @GetMapping("/{closit_id}/highlights")
+    public ApiResponse<UserResponseDTO.UserHighlightSliceDTO> getUserHighlights(
+            @PathVariable("closit_id") String closit_id,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+
+        Slice<Highlight> highlightSlice = userQueryService.getHighlightList(closit_id, PageRequest.of(page, size));
+
+        return ApiResponse.onSuccess(UserConverter.toUserHighlightSliceDTO(highlightSlice));
+    }
+
+    @GetMapping("/{closit_id}/recent-post")
+    @CheckBlocked(targetIdParam = "closit_id")
+    @Operation(summary = "사용자의 최근 게시물 조회",
+            description = """
+            ## 특정 사용자의 최근 게시글 조회
+            ### PathVariable
+            closit_id [사용자의 closit ID]
+            ### Parameters
+            page [조회할 페이지 번호] - 0부터 시작, 10개씩 보여줌
+            """)
+    public ApiResponse<UserResponseDTO.UserRecentPostListDTO> getRecentPostList(@PathVariable("closit_id") String closit_id,
+                                                                                @RequestParam(name = "page") Integer page) {
+
+        Slice<Post> recentPostList = userQueryService.getRecentPostList(closit_id, page);
+
+        return ApiResponse.onSuccess(UserConverter.userRecentPostListDTO(recentPostList));
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/user/controller/UserInteractionController.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/controller/UserInteractionController.java
@@ -1,0 +1,104 @@
+package UMC_7th.Closit.domain.user.controller;
+
+import UMC_7th.Closit.domain.user.converter.UserConverter;
+import UMC_7th.Closit.domain.user.dto.UserRequestDTO;
+import UMC_7th.Closit.domain.user.dto.UserResponseDTO;
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.service.UserCommandService;
+import UMC_7th.Closit.domain.user.service.UserQueryService;
+import UMC_7th.Closit.global.apiPayload.ApiResponse;
+import UMC_7th.Closit.global.validation.annotation.CheckBlocked;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+// 사용자 간 상호작용 관리
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Slf4j
+@Validated
+public class UserInteractionController {
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+
+    @Operation(summary = "사용자 차단", description = "특정 사용자를 차단합니다.")
+    @PostMapping("/block")
+    public ApiResponse<UserResponseDTO.UserBlockResponseDTO> blockUser(@RequestBody UserRequestDTO.BlockUserDTO blockUserDTO) {
+        UserResponseDTO.UserBlockResponseDTO userBlockResponseDTO = userCommandService.blockUser(blockUserDTO);
+        return ApiResponse.onSuccess(userBlockResponseDTO);
+    }
+
+    @Operation(summary = "사용자 차단 해제", description = "특정 사용자의 차단을 해제합니다.")
+    @DeleteMapping("/block")
+    public ApiResponse<String> unblockUser(@RequestBody UserRequestDTO.BlockUserDTO blockUserDTO) {
+        userCommandService.unblockUser(blockUserDTO);
+        return ApiResponse.onSuccess("User unblocked successfully");
+    }
+
+    @Operation(summary = "특정 사용자 차단 여부 조회", description = "특정 사용자의 차단 여부를 합니다.")
+    @GetMapping("/block")
+    public ApiResponse<UserResponseDTO.IsBlockedDTO> isBlockedBy(@RequestParam("closit_id") String closit_id) {
+        return ApiResponse.onSuccess(userQueryService.isBlockedBy(closit_id));
+    }
+
+    @Operation(summary = "사용자 차단 목록 조회", description = "특정 사용자의 차단 목록을 조회합니다.")
+    @GetMapping("/blocks")
+    public ApiResponse<UserResponseDTO.UserBlockListDTO> getBlockedUserList(
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+
+        Slice<String> blockedUserSlice = userQueryService.getBlockedUserList(PageRequest.of(page, size));
+        return ApiResponse.onSuccess(UserConverter.toUserBlockListDTO(blockedUserSlice));
+    }
+
+    @Operation(summary = "사용자의 팔로워 목록 조회",
+            description = """
+            ## 사용자의 팔로워 목록 조회
+            특정 사용자의 팔로워 목록을 페이징하여 조회합니다.
+
+            ### PathVariable
+            - closit_id: 팔로워 목록을 조회할 사용자의 Closit ID
+
+            ### Request Parameters
+            - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
+            - size (기본값: 10): 페이지당 항목 수
+            """)
+    @CheckBlocked(targetIdParam = "closit_id")
+    @GetMapping("/{closit_id}/followers")
+    public ApiResponse<UserResponseDTO.UserFollowerSliceDTO> getUserFollowers (
+            @PathVariable("closit_id") String closit_id,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+
+        Slice<User> followerSlice = userQueryService.getFollowerList(closit_id, PageRequest.of(page, size));
+        return ApiResponse.onSuccess(UserConverter.toUserFollowerSliceDTO(followerSlice));
+    }
+
+    @Operation(summary = "사용자의 팔로잉 목록 조회",
+            description = """
+            ## 사용자의 팔로잉 목록 조회
+            특정 사용자가 팔로우한 유저 목록(팔로잉 목록)을 페이징하여 조회합니다.
+
+            ### PathVariable
+            - closit_id: 팔로잉 목록을 조회할 사용자의 Closit ID
+
+            ### Request Parameters
+            - page (기본값: 0): 조회할 페이지 번호 (0부터 시작)
+            - size (기본값: 10): 페이지당 항목 수
+            """)
+    @CheckBlocked(targetIdParam = "closit_id")
+    @GetMapping("/{closit_id}/following")
+    public ApiResponse<UserResponseDTO.UserFollowingSliceDTO> getUserFollowing(
+            @PathVariable("closit_id") String closit_id,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size) {
+
+        Slice<User> followingSlice = userQueryService.getFollowingList(closit_id, PageRequest.of(page, size));
+        return ApiResponse.onSuccess(UserConverter.toUserFollowingSliceDTO(followingSlice));
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/converter/UserConverter.java
@@ -28,7 +28,6 @@ public class UserConverter {
     public static UserResponseDTO.UserInfoDTO toUserInfoDTO(User user) {
 
         return UserResponseDTO.UserInfoDTO.builder()
-//                .id(user.getId())
                 .role(user.getRole())
                 .clositId(user.getClositId())
                 .name(user.getName())
@@ -41,7 +40,6 @@ public class UserConverter {
     public static UserResponseDTO.UpdateUserInfoDTO toUpdateUserInfoDTO(User user, long followerCount, long followingCount) {
 
         return UserResponseDTO.UpdateUserInfoDTO.builder()
-//                .id(user.getId())
                 .role(user.getRole())
                 .clositId(user.getClositId())
                 .name(user.getName())

--- a/src/main/java/UMC_7th/Closit/domain/user/service/CustomUserDetailService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/CustomUserDetailService.java
@@ -17,11 +17,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CustomUserDetailService implements UserDetailsService {
 
-    private final UserUtil userUtil;
+    private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername (String clositId) throws UsernameNotFoundException {
-        User user = userUtil.getUserByClositIdOrThrow(clositId);
+    public UserDetails loadUserByUsername(String clositId) throws UsernameNotFoundException {
+        User user = userRepository.findByClositId(clositId).orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         return new org.springframework.security.core.userdetails.User(
                 user.getEmail(),

--- a/src/main/java/UMC_7th/Closit/domain/user/service/CustomUserDetailService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/CustomUserDetailService.java
@@ -17,7 +17,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CustomUserDetailService implements UserDetailsService {
 
-    private final UserRepository userRepository;
     private final UserUtil userUtil;
 
     @Override

--- a/src/main/java/UMC_7th/Closit/domain/user/service/CustomUserDetailService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/CustomUserDetailService.java
@@ -18,11 +18,11 @@ import java.util.List;
 public class CustomUserDetailService implements UserDetailsService {
 
     private final UserRepository userRepository;
+    private final UserUtil userUtil;
 
     @Override
-    public UserDetails loadUserByUsername (String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+    public UserDetails loadUserByUsername (String clositId) throws UsernameNotFoundException {
+        User user = userUtil.getUserByClositIdOrThrow(clositId);
 
         return new org.springframework.security.core.userdetails.User(
                 user.getEmail(),

--- a/src/main/java/UMC_7th/Closit/domain/user/service/GoogleOAuthService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/GoogleOAuthService.java
@@ -38,7 +38,7 @@ public class GoogleOAuthService {
             GoogleIdToken idToken = verifier.verify(idTokenString);
 
             if (idToken == null) {
-                log.info("Invalid ID token.", idTokenString);
+                log.debug("Invalid ID token.", idTokenString);
                 throw new UserHandler(ErrorStatus.INVALID_TOKEN);
             }
 
@@ -46,13 +46,13 @@ public class GoogleOAuthService {
 
             // Issuer 체크
             if (!"accounts.google.com".equals(payload.getIssuer()) && !"https://accounts.google.com".equals(payload.getIssuer())) {
-                log.info("Check Issuer");
+                log.debug("Check Issuer");
                 throw new UserHandler(ErrorStatus.INVALID_TOKEN);
             }
 
             // aud (Audience) 검증
             if (!googleClientId.equals(payload.getAudience())) {
-                log.info("Check Audience");
+                log.debug("Check Audience");
                 throw new UserHandler(ErrorStatus.INVALID_TOKEN);
             }
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthService.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthService.java
@@ -11,7 +11,7 @@ public interface UserAuthService {
 
     JwtResponse login(LoginRequestDTO loginRequestDto);
 
-    UserResponseDTO.UserInfoDTO updateUserRole(Long userId, Role role);
+    UserResponseDTO.UserInfoDTO updateUserRole(String clositId, Role role);
 
     JwtResponse refresh(String refreshToken);
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserAuthServiceImpl.java
@@ -17,7 +17,6 @@ import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
 import UMC_7th.Closit.global.common.SocialLoginType;
 import UMC_7th.Closit.security.jwt.JwtTokenProvider;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -109,14 +109,12 @@ public class UserCommandServiceImpl implements UserCommandService {
     @Override
     public User registerProfileImage (String imageUrl) {
 
-        // 현재 로그인된 사용자 정보
         User currentUser = securityUtil.getCurrentUser();
 
         // 사용자가 프로필 이미지를 삭제하려는 경우
         if (imageUrl == null || imageUrl.isEmpty()) {
-            log.info("file is null or empty");
             s3Service.deleteFile(currentUser.getProfileImage());
-            currentUser.updateProfileImage(null);
+            currentUser.updateProfileImage(defaultProfileImage);
             return currentUser;
         }
 
@@ -140,26 +138,15 @@ public class UserCommandServiceImpl implements UserCommandService {
     public User updateUserInfo(UserRequestDTO.UpdateUserDTO updateUserDTO) {
 
         User currentUser = securityUtil.getCurrentUser();
-        Boolean isChanged = false;
 
-        if (updateUserDTO.getName() != null) {
-            currentUser.setName(updateUserDTO.getName());
-            isChanged = true;
-        }
-
-        if (!passwordEncoder.matches(updateUserDTO.getCurrentPassword(), currentUser.getPassword())) {
+        if (!passwordEncoder.matches(updateUserDTO.getPassword(), currentUser.getPassword())) {
             throw new UserHandler(ErrorStatus.INVALID_PASSWORD);
-        } else {
-            if (updateUserDTO.getPassword() != null) {
-                currentUser.updatePassword(passwordEncoder.encode(updateUserDTO.getPassword()));
-                isChanged = true;
-            }
         }
 
-        if (updateUserDTO.getBirth() != null) {
-            currentUser.setBirth(updateUserDTO.getBirth());
-            isChanged = true;
-        }
+        boolean isChanged = false;
+        if (updateUserDTO.getName() != null) { currentUser.setName(updateUserDTO.getName()); isChanged = true; }
+        if (updateUserDTO.getPassword() != null) { currentUser.updatePassword(passwordEncoder.encode(updateUserDTO.getPassword())); isChanged = true; }
+        if (updateUserDTO.getBirth() != null) { currentUser.setBirth(updateUserDTO.getBirth()); isChanged = true; }
 
         if (!isChanged) {
             throw new UserHandler(ErrorStatus.NO_CHANGE_DETECTED);

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserCommandServiceImpl.java
@@ -135,7 +135,6 @@ public class UserCommandServiceImpl implements UserCommandService {
 
     @Override
     public User updateUserInfo(UserRequestDTO.UpdateUserDTO updateUserDTO) {
-
         User currentUser = securityUtil.getCurrentUser();
 
         if (!passwordEncoder.matches(updateUserDTO.getPassword(), currentUser.getPassword())) {
@@ -143,9 +142,19 @@ public class UserCommandServiceImpl implements UserCommandService {
         }
 
         boolean isChanged = false;
-        if (updateUserDTO.getName() != null) { currentUser.setName(updateUserDTO.getName()); isChanged = true; }
-        if (updateUserDTO.getPassword() != null) { currentUser.updatePassword(passwordEncoder.encode(updateUserDTO.getPassword())); isChanged = true; }
-        if (updateUserDTO.getBirth() != null) { currentUser.setBirth(updateUserDTO.getBirth()); isChanged = true; }
+
+        if (updateUserDTO.getName() != null) {
+            currentUser.setName(updateUserDTO.getName());
+            isChanged = true;
+        }
+        if (updateUserDTO.getPassword() != null) {
+            currentUser.updatePassword(passwordEncoder.encode(updateUserDTO.getPassword()));
+            isChanged = true;
+        }
+        if (updateUserDTO.getBirth() != null) {
+            currentUser.setBirth(updateUserDTO.getBirth());
+            isChanged = true;
+        }
 
         if (!isChanged) {
             throw new UserHandler(ErrorStatus.NO_CHANGE_DETECTED);

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserUtil.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserUtil.java
@@ -1,0 +1,26 @@
+package UMC_7th.Closit.domain.user.service;
+
+import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.UserRepository;
+import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
+import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserUtil {
+
+    private final UserRepository userRepository;
+
+    public User getUserByClositIdOrThrow(String clositId) {
+        return userRepository.findByClositId(clositId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    public User getUserByEmailOrThrow(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserUtil.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserUtil.java
@@ -11,7 +11,6 @@ import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
 import UMC_7th.Closit.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserUtil.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserUtil.java
@@ -1,26 +1,99 @@
 package UMC_7th.Closit.domain.user.service;
 
+import UMC_7th.Closit.domain.user.dto.JwtResponse;
+import UMC_7th.Closit.domain.user.entity.OAuthUserInfo;
+import UMC_7th.Closit.domain.user.entity.RefreshToken;
+import UMC_7th.Closit.domain.user.entity.Role;
 import UMC_7th.Closit.domain.user.entity.User;
+import UMC_7th.Closit.domain.user.repository.RefreshTokenRepository;
 import UMC_7th.Closit.domain.user.repository.UserRepository;
 import UMC_7th.Closit.global.apiPayload.code.status.ErrorStatus;
 import UMC_7th.Closit.global.apiPayload.exception.handler.UserHandler;
+import UMC_7th.Closit.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class UserUtil {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
+
+    @Value("${cloud.aws.s3.default-profile-image}")
+    private String defaultProfileImage;
+
+    // ClositId로 사용자 조회
     public User getUserByClositIdOrThrow(String clositId) {
         return userRepository.findByClositId(clositId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     }
 
+    // 이메일로 사용자 조회
     public User getUserByEmailOrThrow(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
     }
+
+    public JwtResponse issueJwtTokens(User user) {
+        String subject = user.getClositId();
+        String accessToken = jwtTokenProvider.createAccessToken(subject, user.getRole());
+        String refreshToken = jwtTokenProvider.createRefreshToken(subject, user.getRole());
+
+        refreshTokenRepository.save(
+                refreshTokenRepository.findByUsername(subject)
+                        .map(rt -> {
+                            rt.updateRefreshToken(refreshToken);
+                            return rt;
+                        })
+                        .orElse(new RefreshToken(subject, refreshToken))
+        );
+
+        return new JwtResponse(user.getClositId(), accessToken, refreshToken);
+    }
+
+
+    // 소셜 로그인 : clositId 생성
+    public String generateUniqueClositId(OAuthUserInfo userInfo) {
+        String base = userInfo.getName().replaceAll("\\s+", "").toLowerCase();
+        String suffix;
+        String randomClositId;
+
+        do {
+            suffix = UUID.randomUUID().toString().substring(0, 6);
+            randomClositId = base + "_" + suffix;
+        } while(userRepository.existsByClositId(randomClositId));
+
+        return randomClositId;
+    }
+
+    // 새로운 사용자 등록
+    public User registerNewUser(OAuthUserInfo userInfo) {
+        if (userRepository.existsByEmail(userInfo.getEmail())) {
+            throw new UserHandler(ErrorStatus.USER_ALREADY_EXIST);
+        }
+        String clositId = generateUniqueClositId(userInfo);
+        String dummyPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+        User newUser = User.builder()
+                .email(userInfo.getEmail())
+                .name(userInfo.getName())
+                .profileImage(defaultProfileImage)
+                .password(dummyPassword)
+                .provider(userInfo.getProvider().toString())
+                .clositId(clositId)
+                .role(Role.USER)
+                .countReport(0)
+                .build();
+
+        return userRepository.save(newUser);
+    }
+
 }

--- a/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
+++ b/src/main/java/UMC_7th/Closit/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package UMC_7th.Closit.security;
 
+import UMC_7th.Closit.domain.user.service.CustomUserDetailService;
 import UMC_7th.Closit.security.jwt.JwtAccessDeniedHandler;
 import UMC_7th.Closit.security.jwt.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class SecurityConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomUserDetailService userDetailService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -54,8 +56,8 @@ public class SecurityConfig {
                                          "/api/auth/oauth/**").permitAll()
                         .anyRequest().authenticated())
                 // UsernamePasswordAuthenticationFilter 전에 JwtAuthenticationFilter 추가
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .userDetailsService(userDetailService);
 
         return http.build();
 

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtAuthenticationFilter.java
@@ -57,11 +57,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // 2. 토큰 유효성 검사
             if (jwtTokenProvider.validateToken(token)) {
                 Claims claims = jwtTokenProvider.getClaims(token);
-                String email = claims.getSubject();
+                String clositId = claims.getSubject();
                 String roleString = claims.get("role", String.class);
 
                 Role role = Role.valueOf(roleString);
-                UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(clositId);
 
                 UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                         userDetails,

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
@@ -114,7 +114,7 @@ public class JwtTokenProvider {
             throw new JwtHandler(ErrorStatus.INVALID_TOKEN);
         } else if (e instanceof UnsupportedJwtException) {
             throw new JwtHandler(ErrorStatus.UNSUPPORTED_TOKEN);
-        }else {
+        } else {
             throw new JwtHandler(ErrorStatus.INVALID_TOKEN);
         }
     }

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
@@ -72,10 +72,8 @@ public class JwtTokenProvider {
         try {
             Jwts.parserBuilder()
                     .setSigningKey(key)
-                    // .setAllowedClockSkewSeconds(60) // Clock Skew 적용 (1분 오차 허용)
                     .build()
                     .parseClaimsJws(token);
-
             return true;
         } catch (ExpiredJwtException e) {
             throw new UserHandler(ErrorStatus.EXPIRED_TOKEN);

--- a/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/UMC_7th/Closit/security/jwt/JwtTokenProvider.java
@@ -38,11 +38,11 @@ public class JwtTokenProvider {
         this.jwtParser = createJwtParser();
     }
 
-    public String createToken(String email, Role role, long validity) {
+    public String createToken(String clositId, Role role, long validity) {
         Instant now = Instant.now();
 
         return Jwts.builder()
-                .setSubject(email)
+                .setSubject(clositId)
                 .claim(ROLE_CLAIM, role)
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(now.plusMillis(validity)))
@@ -50,12 +50,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createAccessToken(String email, Role role) {
-        return createToken(email, role, accessTokenValidity);
+    public String createAccessToken(String clositId, Role role) {
+        return createToken(clositId, role, accessTokenValidity);
     }
 
-    public String createRefreshToken(String email, Role role) {
-        return createToken(email, role, refreshTokenValidity);
+    public String createRefreshToken(String clositId, Role role) {
+        return createToken(clositId, role, refreshTokenValidity);
     }
 
     public Claims getClaims(String token) {


### PR DESCRIPTION
## 🔗 연관된 이슈

- #302 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
1. 메서드 추출
    - 의도를 명확히 알 수 있을 경우에 적용 → 가독성 개선
    - 이후 재사용 가능성이 높은 코드에 대해 적용
    - 로그 처리나 예외 처리 시 메서드 한 곳에서 처리하는 것이 더 용이해질 수 있는 경우에 적용
2. Userutil 클래스 생성
    - 반복 사용이 예상되는 코드들을 저장
    - 블랙박스 메서드로 동작하여 내부 동작에 대해 구체적으로 알 필요가 없으며, 코드 가독성이 개선될 수 있는 코드들을 하나의 메서드 형태로 추출하여 저장

3. 컨트롤러 분리
- 하나의 UserController에서 사용자 정보 관리, 팔로우/차단, 계정 관리, 정보 조회 등 너무 많은 책임을 가지고 있었습니다.
- 따라서 각 API 역할을 분리하여 컨트롤러를 분리했습니다. (Endpoint 변경 x)
- 추가된 컨트롤러
    - `UserAccountController` : 탈퇴, 비활성화 등 사용자 계정 상 관리 담당
    - `UserInteractionController` : 사용자 차단, 팔로워/팔로잉 조회 등 사용자 간 상호작용을 담당.
    - `UserContentController` : 하이라이트, 게시물 등 사용자가 만든 컨텐츠 조회하는 역할 담당.

## 📸 스크린샷


## 💬 리뷰 요구사항
추가 개선 사항을 발견하시고 알려주시면 반영하겠습니다.
리팩토링을 함으로써 더 복잡하거나 관리가 어려워진 것 같은 부분이 있는지도 살펴봐주시면 감사하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 계정 관리, 콘텐츠 조회, 사용자 간 상호작용(차단, 팔로우 등)을 위한 새로운 REST API 컨트롤러가 추가되었습니다.
  * 사용자 관련 유틸리티 클래스가 도입되어 JWT 발급, 사용자 등록, Closit ID 생성 등 기능이 개선되었습니다.

* **기능 개선**
  * 사용자 식별 방식이 이메일에서 Closit ID 기반으로 일원화되었습니다.
  * JWT 토큰 처리 및 예외 처리 구조가 개선되어 보안성과 유지보수성이 향상되었습니다.
  * 기존 사용자 컨트롤러에서 차단, 팔로우, 하이라이트, 탈퇴 등 일부 엔드포인트가 분리 및 재구성되었습니다.

* **버그 수정**
  * 사용자 정보 수정 시 비밀번호 비교 로직이 올바르게 동작하도록 수정되었습니다.

* **리팩터링**
  * 서비스 계층에서 사용자 조회 및 예외 처리가 유틸리티 클래스로 일원화되었습니다.
  * 코드 구조가 모듈화되어 중복이 감소하고 가독성이 향상되었습니다.

* **스타일**
  * 일부 로그 레벨 및 코드 포맷이 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->