### PR TITLE
fix: 차단 여부 조회 수정

### DIFF
--- a/src/main/java/UMC_7th/Closit/domain/user/repository/BlockRepository.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/repository/BlockRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
-    boolean existsByBlockerIdAndBlockedId(String blocker, String blocked);
+    boolean existsByBlockerIdAndBlockedId(String blockerId, String blockedId);
 
     Optional<Block> findByBlockerIdAndBlockedId (String blockerId, String blockedId);
 

--- a/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/UMC_7th/Closit/domain/user/service/UserQueryServiceImpl.java
@@ -109,11 +109,9 @@ public class UserQueryServiceImpl implements UserQueryService {
 
         User currentUser = securityUtil.getCurrentUser();
 
-        UserResponseDTO.IsBlockedDTO isblockedDTO = UserResponseDTO.IsBlockedDTO.builder()
-                .isBlocked(userBlockRepository.existsByBlockerIdAndBlockedId(targetClositId, currentUser.getClositId()))
+        return UserResponseDTO.IsBlockedDTO.builder()
+                .isBlocked(userBlockRepository.existsByBlockerIdAndBlockedId(currentUser.getClositId(), targetClositId))
                 .build();
-
-        return isblockedDTO;
     }
 
     @Override


### PR DESCRIPTION
## 🔗 연관된 이슈

- #304 

- blockerId & blockedId 반대로 돼있었음

## 📸 스크린샷
<img width="1307" height="350" alt="image" src="https://github.com/user-attachments/assets/adcba585-51cc-4921-996c-4b4e81952130" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 차단 여부 확인 로직이 올바르게 동작하도록 수정되었습니다. 이제 사용자가 상대방을 차단했는지 정확하게 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->